### PR TITLE
[#3] Set up CD for Android (Firebase)

### DIFF
--- a/.github/workflows/android_deploy_production.yml
+++ b/.github/workflows/android_deploy_production.yml
@@ -34,7 +34,7 @@ jobs:
         env:
           ENV_PRODUCTION: ${{ secrets.ENV_PRODUCTION }}
         run: |
-          echo $ENV_PRODUCTION > .env
+          echo "$ENV_PRODUCTION" > .env
 
       # App Bundle requires Firebase connected to Play Store to upload https://appdistribution.page.link/KPoa
       - name: Build Android apk

--- a/.github/workflows/android_deploy_staging.yml
+++ b/.github/workflows/android_deploy_staging.yml
@@ -34,7 +34,7 @@ jobs:
         env:
           ENV_STAGING: ${{ secrets.ENV_STAGING }}
         run: |
-          echo $ENV_STAGING > .env.staging
+          echo "$ENV_STAGING" > .env.staging
 
       # App Bundle requires Firebase connected to Play Store to upload https://appdistribution.page.link/KPoa
       - name: Build Android apk

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -83,6 +83,10 @@ class HomeScreen extends StatelessWidget {
               FlutterConfig.get('SECRET'),
               style: const TextStyle(color: Colors.black, fontSize: 24),
             ),
+            Text(
+              FlutterConfig.get('REST_API_ENDPOINT'),
+              style: const TextStyle(color: Colors.black, fontSize: 24),
+            ),
             const SizedBox(height: 24),
             ElevatedButton(
               onPressed: () => context.go('/$routePathSecondScreen'),


### PR DESCRIPTION
Closes https://github.com/nimblehq/ic-flutter-taher-toby/issues/3

## What happened 👀

Thanks to flutter-templates, I didn't have to add `android_deploy_staging.yml` & `android_deploy_production.yml` myself.

However, there was one issue regarding the environment variables when testing with **Firebase app tester.**

## Insights 💭 

When I added `ENV_STAGING` & `ENV_PRODUCTION` to GitHub secrets:

```
SECRET=
REST_API_ENDPOINT=
``` 

it was parsed to:

```
SECRET=REST_API_ENDPOINT=
```

To resolve this issue, [I wrapped the environment variable with quotes ](https://medium.com/tarkalabs-til/using-large-multi-line-secrets-in-github-actions-74289ba4c796)

## Proof Of Work 📹

I added this to GitHub secrets, for testing:

```
SECRET="MY_SECRET"
REST_API_ENDPOINT="MY_ENDPOINT"
```

<img width="250" alt="Screen Shot 2023-03-21 at 17 45 20" src="https://user-images.githubusercontent.com/18277915/226583745-dd750446-a6ef-4958-a15a-06780142123f.png">