### PR TITLE
[#16][#17] [UI][Integrate] As a user, I can see the loading screen for surveys

### DIFF
--- a/lib/theme/app_dimensions.dart
+++ b/lib/theme/app_dimensions.dart
@@ -1,6 +1,7 @@
 class AppDimensions {
   static const double radius10 = 10;
   static const double radius12 = 12;
+  static const double radius14 = 14;
 
   static const double spacing4 = 4;
   static const double spacing8 = 8;
@@ -21,6 +22,8 @@ class AppDimensions {
   static const double textSize28 = 28;
   static const double textSize34 = 34;
 
-  static const homeAvatarSize = 18.0;
+  static const homeAvatarSize = 36.0;
   static const homeSurveyPageIndicatorSize = 8.0;
+
+  static const homeSkeletonLoadingDefaultHeight = 20.0;
 }

--- a/lib/ui/home/home_screen.dart
+++ b/lib/ui/home/home_screen.dart
@@ -6,6 +6,7 @@ import 'package:flutter_survey/model/survey_model.dart';
 import 'package:flutter_survey/ui/home/home_state.dart';
 import 'package:flutter_survey/ui/home/home_view_model.dart';
 import 'package:flutter_survey/ui/home/widget/home_header.dart';
+import 'package:flutter_survey/ui/home/widget/home_skeleton_loading.dart';
 import 'package:flutter_survey/ui/home/widget/home_survey_page_indicator.dart';
 import 'package:flutter_survey/ui/home/widget/home_survey_page_viewer.dart';
 import 'package:flutter_survey/usecases/get_surveys_use_case.dart';
@@ -43,8 +44,8 @@ class HomeScreenState extends ConsumerState<HomeScreen> {
     final surveys = ref.watch(_surveysStreamProvider).value ?? [];
     final errorMessage = ref.watch(_errorStreamProvider).value ?? "";
     return ref.watch(homeViewModelProvider).when(
-          init: () =>
-              _buildHomeScreen(surveys: surveys, errorMessage: errorMessage),
+          init: () => const HomeSkeletonLoading(),
+          loading: () => const HomeSkeletonLoading(),
           loadSurveysSuccess: () =>
               _buildHomeScreen(surveys: surveys, errorMessage: errorMessage),
           loadSurveysError: () =>

--- a/lib/ui/home/home_state.dart
+++ b/lib/ui/home/home_state.dart
@@ -6,6 +6,8 @@ part 'home_state.freezed.dart';
 class HomeState with _$HomeState {
   const factory HomeState.init() = _Init;
 
+  const factory HomeState.loading() = _Loading;
+
   const factory HomeState.loadSurveysSuccess() = _LoadSurveysSuccess;
 
   const factory HomeState.loadSurveysError() = _LoadSurveysError;

--- a/lib/ui/home/home_view_model.dart
+++ b/lib/ui/home/home_view_model.dart
@@ -22,6 +22,7 @@ class HomeViewModel extends StateNotifier<HomeState> {
   Stream<String?> get error => _error.stream;
 
   void loadSurveys() async {
+    state = const HomeState.loading();
     final result = await _getSurveysUseCase.call(GetSurveysInput(
       pageNumber: _surveysPageNumber,
       pageSize: _surveysPageSize,

--- a/lib/ui/home/widget/home_header.dart
+++ b/lib/ui/home/widget/home_header.dart
@@ -35,7 +35,7 @@ class HomeHeader extends StatelessWidget {
             Padding(
               padding: const EdgeInsets.only(top: AppDimensions.spacing20),
               child: CircleAvatar(
-                radius: AppDimensions.homeAvatarSize,
+                radius: AppDimensions.homeAvatarSize / 2,
                 backgroundImage: AssetImage(Assets.images.dummyAvatar.path),
               ),
             ),

--- a/lib/ui/home/widget/home_skeleton_loading.dart
+++ b/lib/ui/home/widget/home_skeleton_loading.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_survey/theme/app_dimensions.dart';
+import 'package:shimmer/shimmer.dart';
+
+class HomeSkeletonLoading extends StatelessWidget {
+  const HomeSkeletonLoading({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final screenWidth = MediaQuery.of(context).size.width;
+    return SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.only(
+            left: AppDimensions.spacing20,
+            top: AppDimensions.spacing28,
+            right: AppDimensions.spacing20),
+        child: Shimmer.fromColors(
+          baseColor: Colors.white12,
+          highlightColor: Colors.white30,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              buildHeaderSkeleton(screenWidth),
+              const Expanded(child: SizedBox.shrink()),
+              _buildSkeleton(width: screenWidth / 6),
+              const SizedBox(height: AppDimensions.spacing18),
+              _buildSkeleton(width: screenWidth / 1.5),
+              const SizedBox(height: AppDimensions.spacing10),
+              _buildSkeleton(width: screenWidth / 3),
+              const SizedBox(height: AppDimensions.spacing18),
+              _buildSkeleton(width: screenWidth / 1.2),
+              const SizedBox(height: AppDimensions.spacing10),
+              _buildSkeleton(width: screenWidth / 1.5),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Row buildHeaderSkeleton(double screenWidth) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              _buildSkeleton(width: screenWidth / 2),
+              const SizedBox(height: AppDimensions.spacing16),
+              _buildSkeleton(width: screenWidth / 3),
+            ],
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.only(top: AppDimensions.spacing18),
+          child: _buildSkeleton(
+              width: AppDimensions.homeAvatarSize,
+              height: AppDimensions.homeAvatarSize,
+              borderRadius: AppDimensions.homeAvatarSize),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildSkeleton({
+    required double width,
+    double height = AppDimensions.homeSkeletonLoadingDefaultHeight,
+    double borderRadius = AppDimensions.radius14,
+  }) {
+    return Container(
+      width: width,
+      height: height,
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(borderRadius),
+        color: Colors.white,
+      ),
+    );
+  }
+}

--- a/lib/ui/home/widget/home_skeleton_loading.dart
+++ b/lib/ui/home/widget/home_skeleton_loading.dart
@@ -11,9 +11,10 @@ class HomeSkeletonLoading extends StatelessWidget {
     return SafeArea(
       child: Padding(
         padding: const EdgeInsets.only(
-            left: AppDimensions.spacing20,
-            top: AppDimensions.spacing28,
-            right: AppDimensions.spacing20),
+          left: AppDimensions.spacing20,
+          top: AppDimensions.spacing28,
+          right: AppDimensions.spacing20,
+        ),
         child: Shimmer.fromColors(
           baseColor: Colors.white12,
           highlightColor: Colors.white30,
@@ -56,9 +57,10 @@ class HomeSkeletonLoading extends StatelessWidget {
         Padding(
           padding: const EdgeInsets.only(top: AppDimensions.spacing18),
           child: _buildSkeleton(
-              width: AppDimensions.homeAvatarSize,
-              height: AppDimensions.homeAvatarSize,
-              borderRadius: AppDimensions.homeAvatarSize),
+            width: AppDimensions.homeAvatarSize,
+            height: AppDimensions.homeAvatarSize,
+            borderRadius: AppDimensions.homeAvatarSize,
+          ),
         ),
       ],
     );

--- a/lib/ui/home/widget/home_skeleton_loading.dart
+++ b/lib/ui/home/widget/home_skeleton_loading.dart
@@ -31,6 +31,7 @@ class HomeSkeletonLoading extends StatelessWidget {
               _buildSkeleton(width: screenWidth / 1.2),
               const SizedBox(height: AppDimensions.spacing10),
               _buildSkeleton(width: screenWidth / 1.5),
+              const SizedBox(height: AppDimensions.spacing54),
             ],
           ),
         ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -724,6 +724,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.3"
+  shimmer:
+    dependency: "direct main"
+    description:
+      name: shimmer
+      sha256: "1f1009b5845a1f88f1c5630212279540486f97409e9fc3f63883e71070d107bf"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,6 +42,7 @@ dependencies:
   permission_handler: ^8.3.0
   retrofit: ^3.0.1+1
   rxdart: ^0.27.7
+  shimmer: ^2.0.0
 
 dev_dependencies:
   build_runner: ^2.2.1

--- a/test/ui/home/home_view_model_test.dart
+++ b/test/ui/home/home_view_model_test.dart
@@ -55,10 +55,15 @@ void main() {
       final surveysStream = homeViewModel.surveys;
       final stateStream = homeViewModel.stream;
 
-      homeViewModel.loadSurveys();
-
       expect(surveysStream, emitsInOrder([surveys]));
-      expect(stateStream, emitsInOrder([const HomeState.loadSurveysSuccess()]));
+      expect(
+          stateStream,
+          emitsInOrder([
+            const HomeState.loading(),
+            const HomeState.loadSurveysSuccess(),
+          ]));
+
+      homeViewModel.loadSurveys();
     });
 
     test(
@@ -69,17 +74,22 @@ void main() {
       final errorStream = homeViewModel.error;
       final stateStream = homeViewModel.stream;
 
-      homeViewModel.loadSurveys();
-
       expect(
           errorStream,
           emitsInOrder(
               [NetworkExceptions.getErrorMessage(exception.actualException)]));
-      expect(stateStream, emitsInOrder([const HomeState.loadSurveysError()]));
+      expect(
+          stateStream,
+          emitsInOrder([
+            const HomeState.loading(),
+            const HomeState.loadSurveysError(),
+          ]));
+
+      homeViewModel.loadSurveys();
     });
 
     tearDown(() {
-      addTearDown(providerContainer.dispose);
+      providerContainer.dispose;
     });
   });
 }

--- a/test/ui/home/home_view_model_test.dart
+++ b/test/ui/home/home_view_model_test.dart
@@ -57,11 +57,12 @@ void main() {
 
       expect(surveysStream, emitsInOrder([surveys]));
       expect(
-          stateStream,
-          emitsInOrder([
-            const HomeState.loading(),
-            const HomeState.loadSurveysSuccess(),
-          ]));
+        stateStream,
+        emitsInOrder([
+          const HomeState.loading(),
+          const HomeState.loadSurveysSuccess(),
+        ]),
+      );
 
       homeViewModel.loadSurveys();
     });
@@ -79,11 +80,12 @@ void main() {
           emitsInOrder(
               [NetworkExceptions.getErrorMessage(exception.actualException)]));
       expect(
-          stateStream,
-          emitsInOrder([
-            const HomeState.loading(),
-            const HomeState.loadSurveysError(),
-          ]));
+        stateStream,
+        emitsInOrder([
+          const HomeState.loading(),
+          const HomeState.loadSurveysError(),
+        ]),
+      );
 
       homeViewModel.loadSurveys();
     });


### PR DESCRIPTION
Closes https://github.com/nimblehq/ic-flutter-taher-toby/issues/16
Closes https://github.com/nimblehq/ic-flutter-taher-toby/issues/17

## What happened 👀

- Add a skeleton widget to indicate the loading process of the surveys on the home screen
- Add [shimmer](https://pub.dev/packages/shimmer), for the loading animations

## Proof Of Work 📹

Please note that the emulator is a bit laggy

**SUCCESS CASE:** 

https://user-images.githubusercontent.com/18277915/229420152-bbd37cef-7d07-4aed-87da-10f0434dadc7.mov


**ERROR CASE:** 

https://user-images.githubusercontent.com/18277915/229420352-cbe9f01d-acf6-4cb6-a256-283d74ce2c5d.mov