### PR TITLE
[#14] [Integrate] As a user, I can cache the list of surveys

### DIFF
--- a/lib/api/repository/survey_repository.dart
+++ b/lib/api/repository/survey_repository.dart
@@ -16,7 +16,10 @@ class SurveyRepositoryImpl extends SurveyRepository {
   final SurveyService _surveyService;
   final SurveyStorage _surveyStorage;
 
-  SurveyRepositoryImpl(this._surveyService, this._surveyStorage);
+  SurveyRepositoryImpl(
+    this._surveyService,
+    this._surveyStorage,
+  );
 
   @override
   Future<List<SurveyModel>> getSurveys({

--- a/lib/api/repository/survey_repository.dart
+++ b/lib/api/repository/survey_repository.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_survey/api/survey_service.dart';
 import 'package:flutter_survey/api/exception/network_exceptions.dart';
+import 'package:flutter_survey/database/survey_storage.dart';
 import 'package:flutter_survey/model/survey_model.dart';
 import 'package:injectable/injectable.dart';
 
@@ -13,8 +14,9 @@ abstract class SurveyRepository {
 @Singleton(as: SurveyRepository)
 class SurveyRepositoryImpl extends SurveyRepository {
   final SurveyService _surveyService;
+  final SurveyStorage _surveyStorage;
 
-  SurveyRepositoryImpl(this._surveyService);
+  SurveyRepositoryImpl(this._surveyService, this._surveyStorage);
 
   @override
   Future<List<SurveyModel>> getSurveys({
@@ -24,7 +26,10 @@ class SurveyRepositoryImpl extends SurveyRepository {
     try {
       final response = await _surveyService.getSurveys(pageNumber, pageSize);
       final surveys = response.surveys ?? [];
-      return surveys.map((item) => SurveyModel.fromResponse(item)).toList();
+      final surveyModels =
+          surveys.map((item) => SurveyModel.fromResponse(item)).toList();
+      _surveyStorage.saveSurveys(surveyModels);
+      return surveyModels;
     } catch (exception) {
       throw NetworkExceptions.fromDioException(exception);
     }

--- a/lib/database/hive.dart
+++ b/lib/database/hive.dart
@@ -1,0 +1,7 @@
+import 'package:flutter_survey/model/survey_model.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+
+Future<void> configureLocalStorage() async {
+  await Hive.initFlutter();
+  Hive.registerAdapter(SurveyModelAdapter());
+}

--- a/lib/database/survey_storage.dart
+++ b/lib/database/survey_storage.dart
@@ -1,0 +1,27 @@
+import 'package:flutter_survey/model/survey_model.dart';
+import 'package:hive/hive.dart';
+
+const String _surveysKey = 'surveys';
+
+abstract class SurveyStorage {
+  List<SurveyModel> get surveys;
+
+  void saveSurveys(List<SurveyModel> surveys);
+}
+
+class SurveyStorageImpl extends SurveyStorage {
+  final Box _surveysBox;
+
+  SurveyStorageImpl(this._surveysBox);
+
+  @override
+  List<SurveyModel> get surveys {
+    List<dynamic> value = _surveysBox.get(_surveysKey, defaultValue: []);
+    return List<SurveyModel>.from(value);
+  }
+
+  @override
+  void saveSurveys(List<SurveyModel> surveys) async {
+    await _surveysBox.put(_surveysKey, surveys);
+  }
+}

--- a/lib/di/di.dart
+++ b/lib/di/di.dart
@@ -6,4 +6,4 @@ import 'di.config.dart';
 final getIt = GetIt.instance;
 
 @InjectableInit()
-void configureDependencyInjection() => getIt.init();
+Future<void> configureDependencyInjection() async => getIt.init();

--- a/lib/di/module/storage_module.dart
+++ b/lib/di/module/storage_module.dart
@@ -1,0 +1,15 @@
+import 'package:flutter_survey/database/survey_storage.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+import 'package:injectable/injectable.dart';
+
+const String _surveysBoxName = 'surveysBox';
+
+@module
+abstract class StorageModule {
+  @Singleton(as: SurveyStorage)
+  @preResolve
+  Future<SurveyStorageImpl> provideSurveyStorage() async {
+    var box = await Hive.openBox(_surveysBoxName);
+    return SurveyStorageImpl(box);
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,14 +3,16 @@ import 'package:flutter/services.dart';
 import 'package:flutter_config/flutter_config.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flutter_survey/di/provider/di.dart';
+import 'package:flutter_survey/di/di.dart';
+import 'package:flutter_survey/database/hive.dart';
 import 'package:flutter_survey/theme/app_theme.dart';
 import 'package:flutter_survey/app_navigator.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await FlutterConfig.loadEnvVariables();
-  configureDependencyInjection();
+  await configureLocalStorage();
+  await configureDependencyInjection();
   _setTransparentStatusBar();
   runApp(const ProviderScope(
     child: SurveyApp(),

--- a/lib/model/survey_model.dart
+++ b/lib/model/survey_model.dart
@@ -1,10 +1,21 @@
 import 'package:equatable/equatable.dart';
 import 'package:flutter_survey/api/response/survey_response.dart';
+import 'package:hive_flutter/hive_flutter.dart';
 
+part 'survey_model.g.dart';
+
+@HiveType(typeId: 0)
 class SurveyModel extends Equatable {
+  @HiveField(0)
   final String id;
+
+  @HiveField(1)
   final String title;
+
+  @HiveField(2)
   final String description;
+
+  @HiveField(3)
   final String coverImageUrl;
 
   const SurveyModel({

--- a/lib/ui/home/home_screen.dart
+++ b/lib/ui/home/home_screen.dart
@@ -16,9 +16,7 @@ import 'package:flutter_survey/ui/widget/snack_bar.dart';
 final homeViewModelProvider =
     StateNotifierProvider.autoDispose<HomeViewModel, HomeState>((ref) {
   return HomeViewModel(
-      getIt.get<GetCachedSurveysUseCase>(),
-      getIt.get<GetSurveysUseCase>()
-  );
+      getIt.get<GetCachedSurveysUseCase>(), getIt.get<GetSurveysUseCase>());
 });
 
 final _surveysStreamProvider = StreamProvider.autoDispose<List<SurveyModel>>(
@@ -52,7 +50,7 @@ class HomeScreenState extends ConsumerState<HomeScreen> {
           init: () => const HomeSkeletonLoading(),
           loading: () => const HomeSkeletonLoading(),
           loadCachedSurveysSuccess: () =>
-            _buildHomeScreen(surveys: surveys, errorMessage: errorMessage),
+              _buildHomeScreen(surveys: surveys, errorMessage: errorMessage),
           loadSurveysSuccess: () =>
               _buildHomeScreen(surveys: surveys, errorMessage: errorMessage),
           loadSurveysError: () =>

--- a/lib/ui/home/home_screen.dart
+++ b/lib/ui/home/home_screen.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_survey/theme/app_dimensions.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flutter_survey/di/provider/di.dart';
+import 'package:flutter_survey/di/di.dart';
 import 'package:flutter_survey/model/survey_model.dart';
 import 'package:flutter_survey/ui/home/home_state.dart';
 import 'package:flutter_survey/ui/home/home_view_model.dart';

--- a/lib/ui/home/home_screen.dart
+++ b/lib/ui/home/home_screen.dart
@@ -9,12 +9,16 @@ import 'package:flutter_survey/ui/home/widget/home_header.dart';
 import 'package:flutter_survey/ui/home/widget/home_skeleton_loading.dart';
 import 'package:flutter_survey/ui/home/widget/home_survey_page_indicator.dart';
 import 'package:flutter_survey/ui/home/widget/home_survey_page_viewer.dart';
+import 'package:flutter_survey/usecases/get_cached_surveys_use_case.dart';
 import 'package:flutter_survey/usecases/get_surveys_use_case.dart';
 import 'package:flutter_survey/ui/widget/snack_bar.dart';
 
 final homeViewModelProvider =
     StateNotifierProvider.autoDispose<HomeViewModel, HomeState>((ref) {
-  return HomeViewModel(getIt.get<GetSurveysUseCase>());
+  return HomeViewModel(
+      getIt.get<GetCachedSurveysUseCase>(),
+      getIt.get<GetSurveysUseCase>()
+  );
 });
 
 final _surveysStreamProvider = StreamProvider.autoDispose<List<SurveyModel>>(
@@ -36,6 +40,7 @@ class HomeScreenState extends ConsumerState<HomeScreen> {
   @override
   void initState() {
     super.initState();
+    ref.read(homeViewModelProvider.notifier).loadCachedSurveys();
     ref.read(homeViewModelProvider.notifier).loadSurveys();
   }
 
@@ -46,6 +51,8 @@ class HomeScreenState extends ConsumerState<HomeScreen> {
     return ref.watch(homeViewModelProvider).when(
           init: () => const HomeSkeletonLoading(),
           loading: () => const HomeSkeletonLoading(),
+          loadCachedSurveysSuccess: () =>
+            _buildHomeScreen(surveys: surveys, errorMessage: errorMessage),
           loadSurveysSuccess: () =>
               _buildHomeScreen(surveys: surveys, errorMessage: errorMessage),
           loadSurveysError: () =>

--- a/lib/ui/home/home_state.dart
+++ b/lib/ui/home/home_state.dart
@@ -8,7 +8,8 @@ class HomeState with _$HomeState {
 
   const factory HomeState.loading() = _Loading;
 
-  const factory HomeState.loadCachedSurveysSuccess() = _LoadCachedSurveysSuccess;
+  const factory HomeState.loadCachedSurveysSuccess() =
+      _LoadCachedSurveysSuccess;
 
   const factory HomeState.loadSurveysSuccess() = _LoadSurveysSuccess;
 

--- a/lib/ui/home/home_state.dart
+++ b/lib/ui/home/home_state.dart
@@ -8,6 +8,8 @@ class HomeState with _$HomeState {
 
   const factory HomeState.loading() = _Loading;
 
+  const factory HomeState.loadCachedSurveysSuccess() = _LoadCachedSurveysSuccess;
+
   const factory HomeState.loadSurveysSuccess() = _LoadSurveysSuccess;
 
   const factory HomeState.loadSurveysError() = _LoadSurveysError;

--- a/lib/ui/home/widget/home_survey_page_viewer.dart
+++ b/lib/ui/home/widget/home_survey_page_viewer.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_survey/app_navigator.dart';
-import 'package:flutter_survey/di/provider/di.dart';
+import 'package:flutter_survey/di/di.dart';
 import 'package:flutter_survey/model/survey_model.dart';
 import 'package:flutter_survey/ui/home/widget/home_survey_page.dart';
 

--- a/lib/usecases/base/base_use_case.dart
+++ b/lib/usecases/base/base_use_case.dart
@@ -17,3 +17,9 @@ abstract class NoParamsUseCase<T> extends BaseUseCase<Result<T>> {
 
   Future<Result<T>> call();
 }
+
+abstract class SimpleUseCase<T> {
+  const SimpleUseCase();
+
+  T call();
+}

--- a/lib/usecases/get_cached_surveys_use_case.dart
+++ b/lib/usecases/get_cached_surveys_use_case.dart
@@ -1,0 +1,14 @@
+import 'package:flutter_survey/database/survey_storage.dart';
+import 'package:flutter_survey/model/survey_model.dart';
+import 'package:flutter_survey/usecases/base/base_use_case.dart';
+import 'package:injectable/injectable.dart';
+
+@Injectable()
+class GetCachedSurveysUseCase extends SimpleUseCase<List<SurveyModel>> {
+  final SurveyStorage _surveyStorage;
+
+  GetCachedSurveysUseCase(this._surveyStorage);
+
+  @override
+  List<SurveyModel> call() => _surveyStorage.surveys;
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,18 +5,18 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: "4897882604d919befd350648c7f91926a9d5de99e67b455bf0917cc2362f4bb8"
+      sha256: a36ec4843dc30ea6bf652bf25e3448db6c5e8bcf4aa55f063a5d1dad216d8214
       url: "https://pub.dev"
     source: hosted
-    version: "47.0.0"
+    version: "58.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: "690e335554a8385bc9d787117d9eb52c0c03ee207a607e593de3c9d71b1cfe80"
+      sha256: cc4242565347e98424ce9945c819c192ec0838cb9d1f6aa4a97cc96becbc5b27
       url: "https://pub.dev"
     source: hosted
-    version: "4.7.0"
+    version: "5.10.0"
   archive:
     dependency: transitive
     description:
@@ -271,18 +271,18 @@ packages:
     dependency: transitive
     description:
       name: flutter_gen_core
-      sha256: f22863d36b4775d153c5b23f86091115b2f12c4020f6fefb5823bafe59940293
+      sha256: e74db9fc706ce43ef0dfd4b296fcfa10f84c4d862b9b68a087e7c703f97c7a0a
       url: "https://pub.dev"
     source: hosted
-    version: "4.3.0"
+    version: "5.2.0"
   flutter_gen_runner:
     dependency: "direct dev"
     description:
       name: flutter_gen_runner
-      sha256: "16adc8aa4f7bab75630e6cab209b9b1db8ac8ac5db3f586e41d70a2867c575d6"
+      sha256: "434511d7c3f7bb5c67d89a16451056093953bebf7afa8336baeceddfc6fe2a21"
       url: "https://pub.dev"
     source: hosted
-    version: "4.3.0"
+    version: "5.2.0"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -375,6 +375,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  hive:
+    dependency: "direct main"
+    description:
+      name: hive
+      sha256: "8dcf6db979d7933da8217edcec84e9df1bdb4e4edc7fc77dbd5aa74356d6d941"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.3"
+  hive_flutter:
+    dependency: "direct main"
+    description:
+      name: hive_flutter
+      sha256: dca1da446b1d808a51689fb5d0c6c9510c0a2ba01e22805d492c73b68e33eecc
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
+  hive_generator:
+    dependency: "direct dev"
+    description:
+      name: hive_generator
+      sha256: "65998cc4d2cd9680a3d9709d893d2f6bb15e6c1f92626c3f1fa650b4b3281521"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0"
   http:
     dependency: transitive
     description:
@@ -596,6 +620,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.8.2"
+  path_provider:
+    dependency: transitive
+    description:
+      name: path_provider
+      sha256: c7edf82217d4b2952b2129a61d3ad60f1075b9299e629e149a8d2e39c2e6aad4
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.14"
+  path_provider_android:
+    dependency: transitive
+    description:
+      name: path_provider_android
+      sha256: "019f18c9c10ae370b08dce1f3e3b73bc9f58e7f087bb5e921f06529438ac0ae7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.24"
+  path_provider_foundation:
+    dependency: transitive
+    description:
+      name: path_provider_foundation
+      sha256: "818b2dc38b0f178e0ea3f7cf3b28146faab11375985d815942a68eee11c2d0f7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.1"
+  path_provider_linux:
+    dependency: transitive
+    description:
+      name: path_provider_linux
+      sha256: "2ae08f2216225427e64ad224a24354221c2c7907e448e6e0e8b57b1eb9f10ad1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.10"
+  path_provider_platform_interface:
+    dependency: transitive
+    description:
+      name: path_provider_platform_interface
+      sha256: "57585299a729335f1298b43245842678cb9f43a6310351b18fb577d6e33165ec"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.6"
+  path_provider_windows:
+    dependency: transitive
+    description:
+      name: path_provider_windows
+      sha256: f53720498d5a543f9607db4b0e997c4b5438884de25b0f73098cc2671a51b130
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.5"
   permission_handler:
     dependency: "direct main"
     description:
@@ -905,6 +977,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.3"
+  xdg_directories:
+    dependency: transitive
+    description:
+      name: xdg_directories
+      sha256: ee1505df1426458f7f60aac270645098d318a8b4766d85fde75f76f2e21807d1
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   xml:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,6 +24,8 @@ dependencies:
   cupertino_icons: ^1.0.5
   dio: ^4.0.6
   equatable: ^2.0.5
+  hive: ^2.2.3
+  hive_flutter: ^1.1.0
   flutter:
     sdk: flutter
   flutter_config: ^2.0.0
@@ -46,11 +48,12 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.2.1
-  flutter_gen_runner: ^4.3.0
+  flutter_gen_runner: ^5.1.0+1
   flutter_lints: ^2.0.1
   flutter_test:
     sdk: flutter
   freezed: ^2.0.3+1
+  hive_generator: ^2.0.0
   injectable_generator: ^2.1.4
   integration_test:
     sdk: flutter

--- a/test/api/repository/survey_repository_test.dart
+++ b/test/api/repository/survey_repository_test.dart
@@ -13,12 +13,17 @@ void main() {
     'SurveyRepositoryTest',
     () {
       late MockSurveyService mockSurveyService;
+      late MockSurveyStorage mockSurveyStorage;
       late SurveyRepository surveyRepository;
 
       setUp(
         () {
           mockSurveyService = MockSurveyService();
-          surveyRepository = SurveyRepositoryImpl(mockSurveyService);
+          mockSurveyStorage = MockSurveyStorage();
+          surveyRepository = SurveyRepositoryImpl(
+            mockSurveyService,
+            mockSurveyStorage,
+          );
         },
       );
 
@@ -40,6 +45,7 @@ void main() {
               SurveyModel.fromResponse(surveysResponse.surveys![0]));
           expect(surveysModel[1],
               SurveyModel.fromResponse(surveysResponse.surveys![1]));
+          verify(mockSurveyStorage.saveSurveys(surveysModel)).called(1);
         },
       );
 
@@ -52,6 +58,7 @@ void main() {
           result() => surveyRepository.getSurveys(pageNumber: 1, pageSize: 2);
 
           expect(result, throwsA(isA<NetworkExceptions>()));
+          verifyNever(mockSurveyStorage.saveSurveys(any));
         },
       );
     },

--- a/test/mocks/generate_mocks.dart
+++ b/test/mocks/generate_mocks.dart
@@ -1,12 +1,16 @@
 import 'package:dio/dio.dart';
 import 'package:flutter_survey/api/repository/survey_repository.dart';
 import 'package:flutter_survey/api/survey_service.dart';
+import 'package:flutter_survey/database/survey_storage.dart';
+import 'package:flutter_survey/usecases/get_cached_surveys_use_case.dart';
 import 'package:flutter_survey/usecases/get_surveys_use_case.dart';
 import 'package:mockito/annotations.dart';
 
 @GenerateMocks([
+  GetCachedSurveysUseCase,
   GetSurveysUseCase,
   SurveyService,
+  SurveyStorage,
   SurveyRepository,
   DioError,
 ])

--- a/test/ui/home/home_view_model_test.dart
+++ b/test/ui/home/home_view_model_test.dart
@@ -12,22 +12,38 @@ import '../../mocks/generate_mocks.mocks.dart';
 
 void main() {
   group('HomeViewModelTest', () {
+    late MockGetCachedSurveysUseCase mockGetCachedSurveysUseCase;
     late MockGetSurveysUseCase mockGetSurveysUseCase;
     late HomeViewModel homeViewModel;
     late ProviderContainer providerContainer;
 
-    final List<SurveyModel> surveys = <SurveyModel>[
+    final List<SurveyModel> cachedSurveys = <SurveyModel>[
       const SurveyModel(
-        id: '1',
+        id: 'id',
         title: 'title',
         description: 'description',
         coverImageUrl: 'coverImageUrl',
       ),
       const SurveyModel(
-        id: '2',
-        title: 'anotherTitle',
-        description: 'anotherDescription',
-        coverImageUrl: 'anotherCoverImageUrl',
+        id: 'id2',
+        title: 'title2',
+        description: 'description2',
+        coverImageUrl: 'coverImageUrl2',
+      ),
+    ];
+
+    final List<SurveyModel> surveys = <SurveyModel>[
+      const SurveyModel(
+        id: 'id3',
+        title: 'title3',
+        description: 'description3',
+        coverImageUrl: 'coverImageUrl3',
+      ),
+      const SurveyModel(
+        id: 'id4',
+        title: 'title4',
+        description: 'description4',
+        coverImageUrl: 'coverImageUrl4',
       ),
     ];
 
@@ -35,15 +51,33 @@ void main() {
         UseCaseException(const NetworkExceptions.unauthorisedRequest());
 
     setUp(() {
+      mockGetCachedSurveysUseCase = MockGetCachedSurveysUseCase();
       mockGetSurveysUseCase = MockGetSurveysUseCase();
       providerContainer = ProviderContainer(
         overrides: [
           homeViewModelProvider.overrideWithValue(
-            HomeViewModel(mockGetSurveysUseCase),
+            HomeViewModel(
+              mockGetCachedSurveysUseCase,
+              mockGetSurveysUseCase,
+            ),
           ),
         ],
       );
       homeViewModel = providerContainer.read(homeViewModelProvider.notifier);
+    });
+
+    test(
+        'When loading cached surveys successfully, it emits a list of surveys with state LoadCachedSurveysSuccess',
+        () {
+      when(mockGetCachedSurveysUseCase.call()).thenAnswer((_) => cachedSurveys);
+      final surveysStream = homeViewModel.surveys;
+      final stateStream = homeViewModel.stream;
+
+      expect(surveysStream, emitsInOrder([cachedSurveys]));
+      expect(stateStream,
+          emitsInOrder([const HomeState.loadCachedSurveysSuccess()]));
+
+      homeViewModel.loadCachedSurveys();
     });
 
     test(

--- a/test/usecases/get_cached_surveys_use_case_test.dart
+++ b/test/usecases/get_cached_surveys_use_case_test.dart
@@ -1,0 +1,29 @@
+import 'package:flutter_survey/model/survey_model.dart';
+import 'package:flutter_survey/usecases/get_cached_surveys_use_case.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+
+import '../mocks/generate_mocks.mocks.dart';
+
+void main() {
+  group('GetCachedSurveysUseCaseTest', () {
+    late MockSurveyStorage mockSurveyStorage;
+    late GetCachedSurveysUseCase getCachedSurveysUseCase;
+
+    setUp(() async {
+      mockSurveyStorage = MockSurveyStorage();
+      getCachedSurveysUseCase = GetCachedSurveysUseCase(mockSurveyStorage);
+    });
+
+    test(
+        'When fetching cached surveys, it returns cached surveys correspondingly',
+        () async {
+      final surveys = <SurveyModel>[];
+      when(mockSurveyStorage.surveys).thenAnswer((_) => surveys);
+
+      final result = getCachedSurveysUseCase.call();
+
+      expect(result, surveys);
+    });
+  });
+}


### PR DESCRIPTION
Closes https://github.com/nimblehq/ic-flutter-taher-toby/issues/14

## What happened 👀

- Cache surveys:
  1. Display surveys from the API
  2. Cache surveys from the API into local storage
  3. Display surveys from the cache, when the user relaunches the app
- Add tests

## Insight 📝

- Use [Hive](https://pub.dev/packages/hive) to store survey models in local storage.
- Configure DI & DB in `main.dart` correctly with `async` (otherwise there's a race condition)
- Add `SimpleUseCase` to execute use cases that don't require `await`

## Proof Of Work 📹

I tested the app on a fresh install:

https://user-images.githubusercontent.com/18277915/230033187-ca5ff79c-14ff-4b54-92d8-81a851609a3c.mov

