### PR TITLE
[#24] [UI] As a user, I can see the survey questions

### DIFF
--- a/lib/app_navigator.dart
+++ b/lib/app_navigator.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_survey/ui/home/home_screen.dart';
 import 'package:flutter_survey/ui/login/login_screen.dart';
 import 'package:flutter_survey/ui/form/form_screen.dart';
 import 'package:go_router/go_router.dart';

--- a/lib/app_navigator.dart
+++ b/lib/app_navigator.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_survey/ui/home/home_screen.dart';
 import 'package:flutter_survey/ui/login/login_screen.dart';
 import 'package:flutter_survey/ui/form/form_screen.dart';
 import 'package:go_router/go_router.dart';
@@ -31,6 +32,8 @@ class Routes {
 }
 
 abstract class AppNavigator {
+  void navigateBack(BuildContext context);
+
   void navigateToFormScreen({
     required BuildContext context,
     required String surveyId,
@@ -40,6 +43,9 @@ abstract class AppNavigator {
 @Injectable(as: AppNavigator)
 class AppNavigatorImpl extends AppNavigator {
   AppNavigatorImpl();
+
+  @override
+  void navigateBack(BuildContext context) => Navigator.of(context).pop();
 
   @override
   void navigateToFormScreen({

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -3,5 +3,6 @@
   "login": "Log in",
   "password": "Password",
   "start_survey": "Start Survey",
+  "submit_survey": "Submit Survey",
   "today": "Today"
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -37,7 +37,6 @@ class SurveyApp extends StatelessWidget {
       routeInformationProvider: Routes.router.routeInformationProvider,
       routeInformationParser: Routes.router.routeInformationParser,
       routerDelegate: Routes.router.routerDelegate,
-      debugShowCheckedModeBanner: false,
     );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -37,6 +37,7 @@ class SurveyApp extends StatelessWidget {
       routeInformationProvider: Routes.router.routeInformationProvider,
       routeInformationParser: Routes.router.routeInformationParser,
       routerDelegate: Routes.router.routerDelegate,
+      debugShowCheckedModeBanner: false,
     );
   }
 }

--- a/lib/theme/app_colors.dart
+++ b/lib/theme/app_colors.dart
@@ -2,5 +2,7 @@ import 'package:flutter/material.dart';
 
 class AppColors {
   static const blackRussian = Color(0xFF15151A);
+  static const white20 = Color(0x33FFFFFF);
+  static const white50 = Color(0x80FFFFFF);
   static const white70 = Color(0xB3FFFFFF);
 }

--- a/lib/theme/app_dimensions.dart
+++ b/lib/theme/app_dimensions.dart
@@ -25,8 +25,10 @@ class AppDimensions {
 
   static const homeAvatarSize = 36.0;
   static const homeSurveyPageIndicatorSize = 8.0;
-
   static const homeSkeletonLoadingDefaultHeight = 20.0;
+
+  static const closeButtonSize = 28.0;
+  static const closeButtonIconSize = 20.0;
 
   static const primaryButtonHeight = 56.0;
 }

--- a/lib/theme/app_theme.dart
+++ b/lib/theme/app_theme.dart
@@ -38,7 +38,7 @@ class AppTheme {
             // Small / Tag All Caps
             color: Colors.white,
             fontSize: AppDimensions.textSize15,
-            fontWeight: FontWeight.w400,
+            fontWeight: FontWeight.w800,
           ),
           bodySmall: TextStyle(
             // Regular / Paragraph

--- a/lib/ui/form/form_screen.dart
+++ b/lib/ui/form/form_screen.dart
@@ -86,7 +86,6 @@ class FormScreenState extends ConsumerState<FormScreen> {
         children: [
           if (surveyDetails != null) ...[
             DimmedBackground(background: surveyDetails.coverImageUrl),
-            _buildCloseButton(context),
             PageView.builder(
               itemCount: 1 + questionTotal,
               controller: _pageController,
@@ -112,6 +111,7 @@ class FormScreenState extends ConsumerState<FormScreen> {
                 });
               },
             ),
+            _buildCloseButton(context),
             _buildStartSurveyButton(),
             _buildNextSurveyButton(),
             _buildSubmitSurveyButton()

--- a/lib/ui/form/form_screen.dart
+++ b/lib/ui/form/form_screen.dart
@@ -116,12 +116,7 @@ class FormScreenState extends ConsumerState<FormScreen> {
             _buildNextSurveyButton(),
             _buildSubmitSurveyButton()
           ] else ...[
-            Column(
-              children: const [
-                SizedBox(height: AppDimensions.spacing20),
-                BackButton(color: Colors.white)
-              ],
-            )
+            const BackButton(color: Colors.white)
           ],
           if (isLoading) _buildCircularProgressIndicator()
         ],

--- a/lib/ui/form/form_screen.dart
+++ b/lib/ui/form/form_screen.dart
@@ -112,11 +112,20 @@ class FormScreenState extends ConsumerState<FormScreen> {
               },
             ),
             _buildCloseButton(context),
-            _buildStartSurveyButton(),
-            _buildNextSurveyButton(),
-            _buildSubmitSurveyButton()
+            Align(
+              alignment: Alignment.bottomRight,
+              child: _buildStartSurveyButton(),
+            ),
+            Align(
+              alignment: Alignment.bottomRight,
+              child: _buildNextSurveyButton(),
+            ),
+            Align(
+              alignment: Alignment.bottomRight,
+              child: _buildSubmitSurveyButton(),
+            ),
           ] else ...[
-            const BackButton(color: Colors.white)
+            const SafeArea(child: BackButton(color: Colors.white))
           ],
           if (isLoading) _buildCircularProgressIndicator()
         ],
@@ -133,23 +142,23 @@ class FormScreenState extends ConsumerState<FormScreen> {
   Widget _buildCloseButton(BuildContext context) {
     return Visibility(
       visible: _showCloseButton,
-      child: Align(
-        alignment: Alignment.topRight,
-        child: RawMaterialButton(
-          shape: const CircleBorder(),
-          fillColor: AppColors.white20,
-          constraints: const BoxConstraints.tightFor(
-            width: AppDimensions.closeButtonSize,
-            height: AppDimensions.closeButtonSize,
+      child: SafeArea(
+        child: Align(
+          alignment: Alignment.topRight,
+          child: RawMaterialButton(
+            shape: const CircleBorder(),
+            fillColor: AppColors.white20,
+            constraints: const BoxConstraints.tightFor(
+              width: AppDimensions.closeButtonSize,
+              height: AppDimensions.closeButtonSize,
+            ),
+            child: const Icon(
+              Icons.close,
+              color: Colors.white,
+              size: AppDimensions.closeButtonIconSize,
+            ),
+            onPressed: () => _appNavigator.navigateBack(context),
           ),
-          child: const Icon(
-            Icons.close,
-            color: Colors.white,
-            size: AppDimensions.closeButtonIconSize,
-          ),
-          onPressed: () {
-            _appNavigator.navigateBack(context);
-          },
         ),
       ),
     );
@@ -159,18 +168,10 @@ class FormScreenState extends ConsumerState<FormScreen> {
         visible: _showStartSurveyButton,
         child: Padding(
           padding: const EdgeInsets.all(AppDimensions.spacing20),
-          child: Align(
-            alignment: Alignment.bottomRight,
-            child: ElevatedButton(
-              onPressed: () {
-                _pageController.nextPage(
-                  duration: const Duration(milliseconds: 400),
-                  curve: Curves.easeInOut,
-                );
-              },
-              child: Text(
-                AppLocalizations.of(context)!.start_survey,
-              ),
+          child: ElevatedButton(
+            onPressed: () => _navigateNextPage(),
+            child: Text(
+              AppLocalizations.of(context)!.start_survey,
             ),
           ),
         ),
@@ -180,33 +181,29 @@ class FormScreenState extends ConsumerState<FormScreen> {
         visible: _showNextSurveyButton,
         child: Padding(
           padding: const EdgeInsets.all(AppDimensions.spacing20),
-          child: Align(
-            alignment: Alignment.bottomRight,
-            child: NextButton(
-              onNextButtonPressed: () {
-                _pageController.nextPage(
-                  duration: const Duration(milliseconds: _navigationDuration),
-                  curve: Curves.easeInOut,
-                );
-              },
-            ),
+          child: NextButton(
+            onNextButtonPressed: () => _navigateNextPage(),
           ),
         ),
       );
+
+  void _navigateNextPage() {
+    _pageController.nextPage(
+      duration: const Duration(milliseconds: _navigationDuration),
+      curve: Curves.easeInOut,
+    );
+  }
 
   Widget _buildSubmitSurveyButton() => Visibility(
         visible: _showSubmitSurveyButton,
         child: Padding(
           padding: const EdgeInsets.all(AppDimensions.spacing20),
-          child: Align(
-            alignment: Alignment.bottomRight,
-            child: ElevatedButton(
-              onPressed: () {
-                // TODO: Integrate click-event from survey details #25
-              },
-              child: Text(
-                AppLocalizations.of(context)!.submit_survey,
-              ),
+          child: ElevatedButton(
+            onPressed: () {
+              // TODO: Integrate click-event from survey details #25
+            },
+            child: Text(
+              AppLocalizations.of(context)!.submit_survey,
             ),
           ),
         ),

--- a/lib/ui/form/form_screen.dart
+++ b/lib/ui/form/form_screen.dart
@@ -155,66 +155,60 @@ class FormScreenState extends ConsumerState<FormScreen> {
     );
   }
 
-  Widget _buildStartSurveyButton() {
-    return Visibility(
-      visible: _showStartSurveyButton,
-      child: Padding(
-        padding: const EdgeInsets.all(AppDimensions.spacing20),
-        child: Align(
-          alignment: Alignment.bottomRight,
-          child: ElevatedButton(
-            onPressed: () {
-              _pageController.nextPage(
-                duration: const Duration(milliseconds: 400),
-                curve: Curves.easeInOut,
-              );
-            },
-            child: Text(
-              AppLocalizations.of(context)!.start_survey,
+  Widget _buildStartSurveyButton() => Visibility(
+        visible: _showStartSurveyButton,
+        child: Padding(
+          padding: const EdgeInsets.all(AppDimensions.spacing20),
+          child: Align(
+            alignment: Alignment.bottomRight,
+            child: ElevatedButton(
+              onPressed: () {
+                _pageController.nextPage(
+                  duration: const Duration(milliseconds: 400),
+                  curve: Curves.easeInOut,
+                );
+              },
+              child: Text(
+                AppLocalizations.of(context)!.start_survey,
+              ),
             ),
           ),
         ),
-      ),
-    );
-  }
+      );
 
-  Widget _buildNextSurveyButton() {
-    return Visibility(
-      visible: _showNextSurveyButton,
-      child: Padding(
-        padding: const EdgeInsets.all(AppDimensions.spacing20),
-        child: Align(
-          alignment: Alignment.bottomRight,
-          child: NextButton(
-            onNextButtonPressed: () {
-              _pageController.nextPage(
-                duration: const Duration(milliseconds: _navigationDuration),
-                curve: Curves.easeInOut,
-              );
-            },
-          ),
-        ),
-      ),
-    );
-  }
-
-  Widget _buildSubmitSurveyButton() {
-    return Visibility(
-      visible: _showSubmitSurveyButton,
-      child: Padding(
-        padding: const EdgeInsets.all(AppDimensions.spacing20),
-        child: Align(
-          alignment: Alignment.bottomRight,
-          child: ElevatedButton(
-            onPressed: () {
-              // TODO: Integrate click-event from survey details #25
-            },
-            child: Text(
-              AppLocalizations.of(context)!.submit_survey,
+  Widget _buildNextSurveyButton() => Visibility(
+        visible: _showNextSurveyButton,
+        child: Padding(
+          padding: const EdgeInsets.all(AppDimensions.spacing20),
+          child: Align(
+            alignment: Alignment.bottomRight,
+            child: NextButton(
+              onNextButtonPressed: () {
+                _pageController.nextPage(
+                  duration: const Duration(milliseconds: _navigationDuration),
+                  curve: Curves.easeInOut,
+                );
+              },
             ),
           ),
         ),
-      ),
-    );
-  }
+      );
+
+  Widget _buildSubmitSurveyButton() => Visibility(
+        visible: _showSubmitSurveyButton,
+        child: Padding(
+          padding: const EdgeInsets.all(AppDimensions.spacing20),
+          child: Align(
+            alignment: Alignment.bottomRight,
+            child: ElevatedButton(
+              onPressed: () {
+                // TODO: Integrate click-event from survey details #25
+              },
+              child: Text(
+                AppLocalizations.of(context)!.submit_survey,
+              ),
+            ),
+          ),
+        ),
+      );
 }

--- a/lib/ui/form/widget/form_survey_detail_page.dart
+++ b/lib/ui/form/widget/form_survey_detail_page.dart
@@ -16,7 +16,6 @@ class FormSurveyDetailPage extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        const SizedBox(height: AppDimensions.spacing20),
         const BackButton(color: Colors.white),
         const SizedBox(height: AppDimensions.spacing10),
         Padding(

--- a/lib/ui/form/widget/form_survey_detail_page.dart
+++ b/lib/ui/form/widget/form_survey_detail_page.dart
@@ -16,7 +16,7 @@ class FormSurveyDetailPage extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        const BackButton(color: Colors.white),
+        const SafeArea(child: BackButton(color: Colors.white)),
         const SizedBox(height: AppDimensions.spacing10),
         Padding(
           padding: const EdgeInsets.symmetric(

--- a/lib/ui/form/widget/form_survey_question_page.dart
+++ b/lib/ui/form/widget/form_survey_question_page.dart
@@ -1,13 +1,57 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_survey/theme/app_colors.dart';
+import 'package:flutter_survey/theme/app_dimensions.dart';
 
 class FormSurveyQuestionPage extends StatelessWidget {
+  final int questionIndex;
+  final int questionTotal;
+
   const FormSurveyQuestionPage({
     Key? key,
+    required this.questionIndex,
+    required this.questionTotal,
   }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    // TODO: Add UI & integrate question page #24 & #25
-    return const Text("Questions & Answers");
+    return SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(
+          vertical: AppDimensions.spacing54,
+          horizontal: AppDimensions.spacing16,
+        ),
+        child: Column(
+          children: [
+            _buildQuestionCounter(context),
+            const SizedBox(height: AppDimensions.spacing8),
+            _buildQuestion(context),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildQuestionCounter(BuildContext context) {
+    return Align(
+      alignment: Alignment.topLeft,
+      child: Text(
+        "$questionIndex/$questionTotal",
+        style: Theme.of(context)
+            .textTheme
+            .headlineSmall
+            ?.copyWith(color: AppColors.white50),
+      ),
+    );
+  }
+
+  Widget _buildQuestion(BuildContext context) {
+    return Align(
+      alignment: Alignment.topLeft,
+      child: Text(
+        // TODO: Add integration question page #25
+        "How fulfilled did you feel during this WFH period?",
+        style: Theme.of(context).textTheme.titleLarge,
+      ),
+    );
   }
 }

--- a/lib/ui/form/widget/form_survey_question_page.dart
+++ b/lib/ui/form/widget/form_survey_question_page.dart
@@ -21,6 +21,7 @@ class FormSurveyQuestionPage extends StatelessWidget {
           horizontal: AppDimensions.spacing16,
         ),
         child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             _buildQuestionCounter(context),
             const SizedBox(height: AppDimensions.spacing8),
@@ -31,27 +32,17 @@ class FormSurveyQuestionPage extends StatelessWidget {
     );
   }
 
-  Widget _buildQuestionCounter(BuildContext context) {
-    return Align(
-      alignment: Alignment.topLeft,
-      child: Text(
+  Widget _buildQuestionCounter(BuildContext context) => Text(
         "$questionIndex/$questionTotal",
         style: Theme.of(context)
             .textTheme
             .headlineSmall
             ?.copyWith(color: AppColors.white50),
-      ),
-    );
-  }
+      );
 
-  Widget _buildQuestion(BuildContext context) {
-    return Align(
-      alignment: Alignment.topLeft,
-      child: Text(
+  Widget _buildQuestion(BuildContext context) => Text(
         // TODO: Add integration question page #25
         "How fulfilled did you feel during this WFH period?",
         style: Theme.of(context).textTheme.titleLarge,
-      ),
-    );
-  }
+      );
 }


### PR DESCRIPTION
Closes https://github.com/nimblehq/ic-flutter-taher-toby/issues/24

## What happened 👀

- Show start-survey, next-survey, and submit-survey buttons on `form_screen.dart`
- Show survey counter and survey question on `form_survey_question_page.dart`

## Insight 📝

- Swiping is disabled for page-view, by using `physics: const NeverScrollableScrollPhysics()`
- The start-survey, next-survey, and submit-survey buttons are shown/hidden dynamically with `setState()`

**Note**:  Please let me know if there's a better way to handle the buttons 🙏 

## Proof Of Work 📹

https://user-images.githubusercontent.com/18277915/232744483-b2376425-2405-44d4-b46f-8080ad5a7f11.mov
