### PR TITLE
[#25] [Integrate] As a user, I can see the survey questions

### DIFF
--- a/lib/api/response/question_response.dart
+++ b/lib/api/response/question_response.dart
@@ -1,0 +1,18 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'question_response.g.dart';
+
+@JsonSerializable()
+class QuestionResponse {
+  final String? id;
+  final String? text;
+
+  QuestionResponse({
+    required this.id,
+    required this.text,
+  });
+
+  factory QuestionResponse.fromJson(Map<String, dynamic> json) {
+    return _$QuestionResponseFromJson(json);
+  }
+}

--- a/lib/api/response/survey_details_response.dart
+++ b/lib/api/response/survey_details_response.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_survey/api/response/decoder/response_decoder.dart';
+import 'package:flutter_survey/api/response/question_response.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:json_annotation/json_annotation.dart';
 
@@ -6,16 +7,18 @@ part 'survey_details_response.g.dart';
 
 @JsonSerializable()
 class SurveyDetailsResponse {
-  String? id;
-  String? title;
-  String? description;
-  String? coverImageUrl;
+  final String? id;
+  final String? title;
+  final String? description;
+  final String? coverImageUrl;
+  final List<QuestionResponse>? questions;
 
   SurveyDetailsResponse({
     this.id,
     this.title,
     this.description,
     this.coverImageUrl,
+    this.questions
   });
 
   factory SurveyDetailsResponse.fromJson(Map<String, dynamic> json) {

--- a/lib/api/response/survey_details_response.dart
+++ b/lib/api/response/survey_details_response.dart
@@ -18,7 +18,7 @@ class SurveyDetailsResponse {
     this.title,
     this.description,
     this.coverImageUrl,
-    this.questions
+    this.questions,
   });
 
   factory SurveyDetailsResponse.fromJson(Map<String, dynamic> json) {

--- a/lib/model/question_model.dart
+++ b/lib/model/question_model.dart
@@ -1,0 +1,25 @@
+import 'package:equatable/equatable.dart';
+import 'package:flutter_survey/api/response/question_response.dart';
+
+class QuestionModel extends Equatable {
+  final String id;
+  final String text;
+
+  const QuestionModel({
+    required this.id,
+    required this.text,
+  });
+
+  @override
+  List<Object?> get props => [
+        id,
+        text,
+      ];
+
+  factory QuestionModel.fromResponse(QuestionResponse response) {
+    return QuestionModel(
+      id: response.id ?? '',
+      text: response.text ?? '',
+    );
+  }
+}

--- a/lib/model/survey_details_model.dart
+++ b/lib/model/survey_details_model.dart
@@ -1,21 +1,24 @@
 import 'package:equatable/equatable.dart';
 import 'package:flutter_survey/api/response/survey_details_response.dart';
+import 'package:flutter_survey/model/question_model.dart';
 
 class SurveyDetailsModel extends Equatable {
   final String id;
   final String title;
   final String description;
   final String coverImageUrl;
+  final List<QuestionModel> questions;
 
   const SurveyDetailsModel({
     required this.id,
     required this.title,
     required this.description,
     required this.coverImageUrl,
+    required this.questions,
   });
 
   @override
-  List<Object?> get props => [id, title, description, coverImageUrl];
+  List<Object?> get props => [id, title, description, coverImageUrl, questions];
 
   factory SurveyDetailsModel.fromResponse(SurveyDetailsResponse response) {
     return SurveyDetailsModel(
@@ -23,6 +26,9 @@ class SurveyDetailsModel extends Equatable {
       title: response.title ?? "",
       description: response.description ?? "",
       coverImageUrl: response.getHdCoverImageUrl(),
+      questions: (response.questions ?? [])
+          .map((question) => QuestionModel.fromResponse(question))
+          .toList(),
     );
   }
 }

--- a/lib/ui/form/form_screen.dart
+++ b/lib/ui/form/form_screen.dart
@@ -97,7 +97,7 @@ class FormScreenState extends ConsumerState<FormScreen> {
                   );
                 } else {
                   return FormSurveyQuestionPage(
-                    question: questions[index],
+                    question: questions[index - 1],
                     questionIndex: index,
                     questionTotal: questionTotal,
                   );

--- a/lib/ui/form/form_screen.dart
+++ b/lib/ui/form/form_screen.dart
@@ -77,8 +77,8 @@ class FormScreenState extends ConsumerState<FormScreen> {
     SurveyDetailsModel? surveyDetails,
     String errorMessage = "",
   }) {
-    // TODO: Integrate item count from survey details #25
-    const questionTotal = 5;
+    final questions = surveyDetails?.questions ?? [];
+    final questionTotal = questions.length;
     if (errorMessage.isNotEmpty) showSnackBar(context, errorMessage);
     return Scaffold(
       backgroundColor: Colors.black,
@@ -97,6 +97,7 @@ class FormScreenState extends ConsumerState<FormScreen> {
                   );
                 } else {
                   return FormSurveyQuestionPage(
+                    question: questions[index],
                     questionIndex: index,
                     questionTotal: questionTotal,
                   );

--- a/lib/ui/form/widget/form_survey_question_page.dart
+++ b/lib/ui/form/widget/form_survey_question_page.dart
@@ -1,13 +1,16 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_survey/model/question_model.dart';
 import 'package:flutter_survey/theme/app_colors.dart';
 import 'package:flutter_survey/theme/app_dimensions.dart';
 
 class FormSurveyQuestionPage extends StatelessWidget {
+  final QuestionModel question;
   final int questionIndex;
   final int questionTotal;
 
   const FormSurveyQuestionPage({
     Key? key,
+    required this.question,
     required this.questionIndex,
     required this.questionTotal,
   }) : super(key: key);
@@ -41,8 +44,7 @@ class FormSurveyQuestionPage extends StatelessWidget {
       );
 
   Widget _buildQuestion(BuildContext context) => Text(
-        // TODO: Add integration question page #25
-        "How fulfilled did you feel during this WFH period?",
+        question.text,
         style: Theme.of(context).textTheme.titleLarge,
       );
 }

--- a/test/ui/form/form_view_model_test.dart
+++ b/test/ui/form/form_view_model_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_survey/api/exception/network_exceptions.dart';
+import 'package:flutter_survey/model/question_model.dart';
 import 'package:flutter_survey/model/survey_details_model.dart';
 import 'package:flutter_survey/ui/form/form_screen.dart';
 import 'package:flutter_survey/ui/form/form_state.dart';
@@ -21,6 +22,9 @@ void main() {
       title: 'title',
       description: 'description',
       coverImageUrl: 'coverImageUrl',
+      questions: [
+        QuestionModel(id: 'id2', text: 'text2'),
+      ],
     );
 
     final UseCaseException exception =

--- a/test/usecases/get_survey_details_use_case_test.dart
+++ b/test/usecases/get_survey_details_use_case_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_survey/api/exception/network_exceptions.dart';
+import 'package:flutter_survey/model/question_model.dart';
 import 'package:flutter_survey/model/survey_details_model.dart';
 import 'package:flutter_survey/usecases/base/base_use_case.dart';
 import 'package:flutter_survey/usecases/get_survey_details_use_case.dart';
@@ -22,6 +23,9 @@ void main() {
         title: '2',
         description: '3',
         coverImageUrl: '4',
+        questions: [
+          QuestionModel(id: '5', text: '6'),
+        ],
       );
       when(mockSurveyRepository.getSurveyDetails(surveyId: "surveyId"))
           .thenAnswer((_) async => surveyDetailsModel);


### PR DESCRIPTION
Closes https://github.com/nimblehq/ic-flutter-taher-toby/issues/25

## What happened 👀

- Show the correct amount of questions
- Show the actual question text
- Update unit tests

This is achieved by adding `question_response.dart` & `question_model.dart`.

## Insight 📝

```
 factory QuestionResponse.fromJson(Map<String, dynamic> json) {
    return _$QuestionResponseFromJson(json);
  }
```

Note how we don't decode `json` here, because we already decoded it before in `survey_details_response.dart`

## Proof Of Work 📹

https://user-images.githubusercontent.com/18277915/232963096-5a1292a6-e701-4a66-9a2c-40e0acfb3737.mov
