### PR TITLE
[#19] [#20] [Backend] [Integrate] As a user, my token is refreshed when expired

### DIFF
--- a/lib/api/exception/network_exceptions.dart
+++ b/lib/api/exception/network_exceptions.dart
@@ -52,10 +52,10 @@ class NetworkExceptions with _$NetworkExceptions {
             case DioErrorType.cancel:
               networkExceptions = const NetworkExceptions.requestCancelled();
               break;
-            case DioErrorType.connectTimeout:
+            case DioErrorType.connectionTimeout:
               networkExceptions = const NetworkExceptions.requestTimeout();
               break;
-            case DioErrorType.other:
+            case DioErrorType.unknown:
               networkExceptions =
                   const NetworkExceptions.noInternetConnection();
               break;
@@ -65,7 +65,7 @@ class NetworkExceptions with _$NetworkExceptions {
             case DioErrorType.sendTimeout:
               networkExceptions = const NetworkExceptions.sendTimeout();
               break;
-            case DioErrorType.response:
+            case DioErrorType.badResponse:
               switch (error.response?.statusCode) {
                 case 400:
                   networkExceptions = const NetworkExceptions.badRequest();
@@ -102,6 +102,9 @@ class NetworkExceptions with _$NetworkExceptions {
                     "Received invalid status code: $responseCode",
                   );
               }
+              break;
+            default:
+              networkExceptions = const NetworkExceptions.unexpectedError();
               break;
           }
         } else if (error is SocketException) {

--- a/lib/api/repository/authentication_repository.dart
+++ b/lib/api/repository/authentication_repository.dart
@@ -1,18 +1,18 @@
 import 'package:flutter_survey/api/request/login_request.dart';
 import 'package:flutter_survey/api/request/refresh_token_request.dart';
 import 'package:flutter_survey/api/service/authentication_service.dart';
-import 'package:flutter_survey/model/login_model.dart';
+import 'package:flutter_survey/model/auth_token_model.dart';
 import 'package:flutter_survey/api/exception/network_exceptions.dart';
 import 'package:injectable/injectable.dart';
 import 'package:flutter_survey/env.dart';
 
 abstract class AuthenticationRepository {
-  Future<LoginModel> logIn({
+  Future<AuthTokenModel> logIn({
     required String email,
     required String password,
   });
 
-  Future<LoginModel> getAuthToken({
+  Future<AuthTokenModel> getAuthToken({
     required String refreshToken,
   });
 }
@@ -24,7 +24,7 @@ class AuthenticationRepositoryImpl extends AuthenticationRepository {
   AuthenticationRepositoryImpl(this._autenticationService);
 
   @override
-  Future<LoginModel> logIn({
+  Future<AuthTokenModel> logIn({
     required String email,
     required String password,
   }) async {
@@ -37,14 +37,14 @@ class AuthenticationRepositoryImpl extends AuthenticationRepository {
         clientSecret: Env.restApiClientSecret,
       );
       final response = await _autenticationService.logIn(loginRequest);
-      return LoginModel.fromResponse(response);
+      return AuthTokenModel.fromResponse(response);
     } catch (exception) {
       throw NetworkExceptions.fromDioException(exception);
     }
   }
 
   @override
-  Future<LoginModel> getAuthToken({
+  Future<AuthTokenModel> getAuthToken({
     required String refreshToken,
   }) async {
     try {
@@ -54,8 +54,9 @@ class AuthenticationRepositoryImpl extends AuthenticationRepository {
         clientSecret: Env.restApiClientSecret,
         refreshToken: refreshToken,
       );
-      final response = await _autenticationService.getAuthToken(refreshTokenRequest);
-      return LoginModel.fromResponse(response);
+      final response =
+          await _autenticationService.getAuthToken(refreshTokenRequest);
+      return AuthTokenModel.fromResponse(response);
     } catch (exception) {
       throw NetworkExceptions.fromDioException(exception);
     }

--- a/lib/api/repository/authentication_repository.dart
+++ b/lib/api/repository/authentication_repository.dart
@@ -12,7 +12,7 @@ abstract class AuthenticationRepository {
     required String password,
   });
 
-  Future<AuthTokenModel> getAuthToken({
+  Future<AuthTokenModel> refreshToken({
     required String refreshToken,
   });
 }
@@ -44,7 +44,7 @@ class AuthenticationRepositoryImpl extends AuthenticationRepository {
   }
 
   @override
-  Future<AuthTokenModel> getAuthToken({
+  Future<AuthTokenModel> refreshToken({
     required String refreshToken,
   }) async {
     try {
@@ -55,7 +55,7 @@ class AuthenticationRepositoryImpl extends AuthenticationRepository {
         refreshToken: refreshToken,
       );
       final response =
-          await _autenticationService.getAuthToken(refreshTokenRequest);
+          await _autenticationService.refreshToken(refreshTokenRequest);
       return AuthTokenModel.fromResponse(response);
     } catch (exception) {
       throw NetworkExceptions.fromDioException(exception);

--- a/lib/api/repository/authentication_repository.dart
+++ b/lib/api/repository/authentication_repository.dart
@@ -6,6 +6,9 @@ import 'package:flutter_survey/api/exception/network_exceptions.dart';
 import 'package:injectable/injectable.dart';
 import 'package:flutter_survey/env.dart';
 
+const String _grantTypePassword = "password";
+const String _grantTypeRefreshToken = 'refresh_token';
+
 abstract class AuthenticationRepository {
   Future<AuthTokenModel> logIn({
     required String email,
@@ -30,7 +33,7 @@ class AuthenticationRepositoryImpl extends AuthenticationRepository {
   }) async {
     try {
       final LoginRequest loginRequest = LoginRequest(
-        grantType: grantTypePassword,
+        grantType: _grantTypePassword,
         email: email,
         password: password,
         clientId: Env.restApiClientId,
@@ -49,7 +52,7 @@ class AuthenticationRepositoryImpl extends AuthenticationRepository {
   }) async {
     try {
       final RefreshTokenRequest refreshTokenRequest = RefreshTokenRequest(
-        grantType: grantTypeRefreshToken,
+        grantType: _grantTypeRefreshToken,
         clientId: Env.restApiClientId,
         clientSecret: Env.restApiClientSecret,
         refreshToken: refreshToken,

--- a/lib/api/repository/authentication_repository.dart
+++ b/lib/api/repository/authentication_repository.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_survey/api/request/login_request.dart';
+import 'package:flutter_survey/api/request/refresh_token_request.dart';
 import 'package:flutter_survey/api/service/authentication_service.dart';
 import 'package:flutter_survey/model/login_model.dart';
 import 'package:flutter_survey/api/exception/network_exceptions.dart';
@@ -9,6 +10,10 @@ abstract class AuthenticationRepository {
   Future<LoginModel> logIn({
     required String email,
     required String password,
+  });
+
+  Future<LoginModel> getAuthToken({
+    required String refreshToken,
   });
 }
 
@@ -25,13 +30,31 @@ class AuthenticationRepositoryImpl extends AuthenticationRepository {
   }) async {
     try {
       final LoginRequest loginRequest = LoginRequest(
-        grantType: grantType,
+        grantType: grantTypePassword,
         email: email,
         password: password,
         clientId: Env.restApiClientId,
         clientSecret: Env.restApiClientSecret,
       );
       final response = await _autenticationService.logIn(loginRequest);
+      return LoginModel.fromResponse(response);
+    } catch (exception) {
+      throw NetworkExceptions.fromDioException(exception);
+    }
+  }
+
+  @override
+  Future<LoginModel> getAuthToken({
+    required String refreshToken,
+  }) async {
+    try {
+      final RefreshTokenRequest refreshTokenRequest = RefreshTokenRequest(
+        grantType: grantTypeRefreshToken,
+        clientId: Env.restApiClientId,
+        clientSecret: Env.restApiClientSecret,
+        refreshToken: refreshToken,
+      );
+      final response = await _autenticationService.getAuthToken(refreshTokenRequest);
       return LoginModel.fromResponse(response);
     } catch (exception) {
       throw NetworkExceptions.fromDioException(exception);

--- a/lib/api/request/login_request.dart
+++ b/lib/api/request/login_request.dart
@@ -2,8 +2,6 @@ import 'package:json_annotation/json_annotation.dart';
 
 part 'login_request.g.dart';
 
-const String grantTypePassword = "password";
-
 @JsonSerializable()
 class LoginRequest {
   final String grantType;

--- a/lib/api/request/login_request.dart
+++ b/lib/api/request/login_request.dart
@@ -2,7 +2,7 @@ import 'package:json_annotation/json_annotation.dart';
 
 part 'login_request.g.dart';
 
-const String grantType = "password";
+const String grantTypePassword = "password";
 
 @JsonSerializable()
 class LoginRequest {

--- a/lib/api/request/refresh_token_request.dart
+++ b/lib/api/request/refresh_token_request.dart
@@ -2,8 +2,6 @@ import 'package:json_annotation/json_annotation.dart';
 
 part 'refresh_token_request.g.dart';
 
-const String grantTypeRefreshToken = 'refresh_token';
-
 @JsonSerializable()
 class RefreshTokenRequest {
   final String grantType;

--- a/lib/api/request/refresh_token_request.dart
+++ b/lib/api/request/refresh_token_request.dart
@@ -1,0 +1,22 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'refresh_token_request.g.dart';
+
+const String grantTypeRefreshToken = 'refresh_token';
+
+@JsonSerializable()
+class RefreshTokenRequest {
+  final String grantType;
+  final String clientId;
+  final String clientSecret;
+  final String refreshToken;
+
+  RefreshTokenRequest({
+    required this.grantType,
+    required this.clientId,
+    required this.clientSecret,
+    required this.refreshToken,
+  });
+
+  Map<String, dynamic> toJson() => _$RefreshTokenRequestToJson(this);
+}

--- a/lib/api/response/auth_response.dart
+++ b/lib/api/response/auth_response.dart
@@ -1,17 +1,17 @@
 import 'package:json_annotation/json_annotation.dart';
 import 'package:flutter_survey/api/response/decoder/response_decoder.dart';
 
-part 'login_response.g.dart';
+part 'auth_response.g.dart';
 
 @JsonSerializable()
-class LoginResponse {
+class AuthResponse {
   final String? accessToken;
   final String? tokenType;
   final int? expiresIn;
   final String? refreshToken;
   final int? createdAt;
 
-  LoginResponse({
+  AuthResponse({
     this.accessToken,
     this.tokenType,
     this.expiresIn,
@@ -19,6 +19,6 @@ class LoginResponse {
     this.createdAt,
   });
 
-  factory LoginResponse.fromJson(Map<String, dynamic> json) =>
-      _$LoginResponseFromJson(decodeJsonFromData(json));
+  factory AuthResponse.fromJson(Map<String, dynamic> json) =>
+      _$AuthResponseFromJson(decodeJsonFromData(json));
 }

--- a/lib/api/service/authentication_service.dart
+++ b/lib/api/service/authentication_service.dart
@@ -1,14 +1,14 @@
 import 'package:dio/dio.dart';
 import 'package:flutter_survey/api/request/login_request.dart';
 import 'package:flutter_survey/api/request/refresh_token_request.dart';
-import 'package:flutter_survey/api/response/login_response.dart';
+import 'package:flutter_survey/api/response/auth_response.dart';
 import 'package:retrofit/retrofit.dart';
 
 part 'authentication_service.g.dart';
 
 abstract class AuthenticationService {
-  Future<LoginResponse> logIn(@Body() LoginRequest request);
-  Future<LoginResponse> getAuthToken(@Body() RefreshTokenRequest request);
+  Future<AuthResponse> logIn(@Body() LoginRequest request);
+  Future<AuthResponse> getAuthToken(@Body() RefreshTokenRequest request);
 }
 
 @RestApi()
@@ -18,9 +18,9 @@ abstract class AuthenticationServiceImpl extends AuthenticationService {
 
   @override
   @POST('/oauth/token')
-  Future<LoginResponse> logIn(@Body() LoginRequest request);
+  Future<AuthResponse> logIn(@Body() LoginRequest request);
 
   @override
   @POST('/oauth/token')
-  Future<LoginResponse> getAuthToken(@Body() RefreshTokenRequest request);
+  Future<AuthResponse> getAuthToken(@Body() RefreshTokenRequest request);
 }

--- a/lib/api/service/authentication_service.dart
+++ b/lib/api/service/authentication_service.dart
@@ -1,5 +1,6 @@
 import 'package:dio/dio.dart';
 import 'package:flutter_survey/api/request/login_request.dart';
+import 'package:flutter_survey/api/request/refresh_token_request.dart';
 import 'package:flutter_survey/api/response/login_response.dart';
 import 'package:retrofit/retrofit.dart';
 
@@ -7,6 +8,7 @@ part 'authentication_service.g.dart';
 
 abstract class AuthenticationService {
   Future<LoginResponse> logIn(@Body() LoginRequest request);
+  Future<LoginResponse> getAuthToken(@Body() RefreshTokenRequest request);
 }
 
 @RestApi()
@@ -17,4 +19,8 @@ abstract class AuthenticationServiceImpl extends AuthenticationService {
   @override
   @POST('/oauth/token')
   Future<LoginResponse> logIn(@Body() LoginRequest request);
+
+  @override
+  @POST('/oauth/token')
+  Future<LoginResponse> getAuthToken(@Body() RefreshTokenRequest request);
 }

--- a/lib/api/service/authentication_service.dart
+++ b/lib/api/service/authentication_service.dart
@@ -8,7 +8,7 @@ part 'authentication_service.g.dart';
 
 abstract class AuthenticationService {
   Future<AuthResponse> logIn(@Body() LoginRequest request);
-  Future<AuthResponse> getAuthToken(@Body() RefreshTokenRequest request);
+  Future<AuthResponse> refreshToken(@Body() RefreshTokenRequest request);
 }
 
 @RestApi()
@@ -22,5 +22,5 @@ abstract class AuthenticationServiceImpl extends AuthenticationService {
 
   @override
   @POST('/oauth/token')
-  Future<AuthResponse> getAuthToken(@Body() RefreshTokenRequest request);
+  Future<AuthResponse> refreshToken(@Body() RefreshTokenRequest request);
 }

--- a/lib/di/interceptor/app_interceptor.dart
+++ b/lib/di/interceptor/app_interceptor.dart
@@ -4,7 +4,7 @@ import 'dart:developer';
 import 'package:dio/dio.dart';
 import 'package:flutter_survey/database/secure_storage.dart';
 import 'package:flutter_survey/di/di.dart';
-import 'package:flutter_survey/model/login_model.dart';
+import 'package:flutter_survey/model/auth_token_model.dart';
 import 'package:flutter_survey/usecases/refresh_token_use_case.dart';
 import 'package:flutter_survey/usecases/base/base_use_case.dart';
 import 'package:flutter_survey/usecases/store_auth_token_use_case.dart';
@@ -59,12 +59,12 @@ class AppInterceptor extends Interceptor {
           getIt.get<StoreAuthTokenUseCase>();
       final String refreshToken =
           await _secureStorage.readSecureData(refreshTokenKey) ?? '';
-      final result = await refreshTokenUseCase.call(refreshToken);
-      if (result is Success<LoginModel>) {
-        LoginModel tokenData = result.value;
-        final String accessToken = tokenData.accessToken;
-        final String tokenType = tokenData.tokenType;
-        storeAuthTokenUseCase.call(tokenData);
+      final refreshTokenResult = await refreshTokenUseCase.call(refreshToken);
+      if (refreshTokenResult is Success<AuthTokenModel>) {
+        AuthTokenModel authTokenModel = refreshTokenResult.value;
+        final String accessToken = authTokenModel.accessToken;
+        final String tokenType = authTokenModel.tokenType;
+        storeAuthTokenUseCase.call(authTokenModel);
         error.requestOptions.headers[_authorizationHeader] =
             '$tokenType $accessToken';
         final options = Options(
@@ -83,7 +83,7 @@ class AppInterceptor extends Interceptor {
       }
     } catch (exception) {
       final errorString = exception.toString();
-      log('Exception occured $errorString');
+      log('Exception occured when tyr to rfresh token: $errorString');
       // To fix silent error `Error: Bad state: Future already completed` commented the call to handler
       // error details: https://stackoverflow.com/questions/73106834/
       // if (exception is DioError) {

--- a/lib/di/interceptor/app_interceptor.dart
+++ b/lib/di/interceptor/app_interceptor.dart
@@ -1,6 +1,5 @@
 // ignore: unused_import
 import 'dart:io';
-import 'dart:developer';
 import 'package:dio/dio.dart';
 import 'package:flutter_survey/database/secure_storage.dart';
 import 'package:flutter_survey/di/di.dart';
@@ -37,7 +36,6 @@ class AppInterceptor extends Interceptor {
 
   @override
   void onError(DioError err, ErrorInterceptorHandler handler) {
-    handler.next(err);
     final statusCode = err.response?.statusCode;
     if ((statusCode == HttpStatus.forbidden ||
             statusCode == HttpStatus.unauthorized) &&
@@ -82,15 +80,11 @@ class AppInterceptor extends Interceptor {
         handler.next(error);
       }
     } catch (exception) {
-      final errorString = exception.toString();
-      log('Exception occured when tyr to rfresh token: $errorString');
-      // To fix silent error `Error: Bad state: Future already completed` commented the call to handler
-      // error details: https://stackoverflow.com/questions/73106834/
-      // if (exception is DioError) {
-      //   handler.next(exception);
-      // } else {
-      //   handler.next(error);
-      // }
+      if (exception is DioError) {
+        handler.next(exception);
+      } else {
+        handler.next(error);
+      }
     }
   }
 }

--- a/lib/di/interceptor/app_interceptor.dart
+++ b/lib/di/interceptor/app_interceptor.dart
@@ -4,6 +4,7 @@ import 'package:dio/dio.dart';
 import 'package:flutter_survey/database/secure_storage.dart';
 import 'package:flutter_survey/di/di.dart';
 import 'package:flutter_survey/model/auth_token_model.dart';
+import 'package:flutter_survey/usecases/get_auth_token_use_case.dart';
 import 'package:flutter_survey/usecases/refresh_token_use_case.dart';
 import 'package:flutter_survey/usecases/base/base_use_case.dart';
 import 'package:flutter_survey/usecases/store_auth_token_use_case.dart';
@@ -14,6 +15,7 @@ class AppInterceptor extends Interceptor {
   final bool _requireAuthentication;
   final Dio _dio;
   final SecureStorage _secureStorage;
+
   AppInterceptor(
     this._requireAuthentication,
     this._dio,
@@ -55,9 +57,11 @@ class AppInterceptor extends Interceptor {
           getIt.get<RefreshTokenUseCase>();
       final StoreAuthTokenUseCase storeAuthTokenUseCase =
           getIt.get<StoreAuthTokenUseCase>();
-      final String refreshToken =
-          await _secureStorage.readSecureData(refreshTokenKey) ?? '';
-      final refreshTokenResult = await refreshTokenUseCase.call(refreshToken);
+      final GetAuthTokenUseCase getAuthTokenUseCase =
+          getIt.get<GetAuthTokenUseCase>();
+      final AuthTokenModel authTokenModel = await getAuthTokenUseCase.call();
+      final refreshTokenResult =
+          await refreshTokenUseCase.call(authTokenModel.refreshToken);
       if (refreshTokenResult is Success<AuthTokenModel>) {
         AuthTokenModel authTokenModel = refreshTokenResult.value;
         final String accessToken = authTokenModel.accessToken;

--- a/lib/di/provider/dio_provider.dart
+++ b/lib/di/provider/dio_provider.dart
@@ -3,6 +3,9 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_survey/di/di.dart';
 import 'package:flutter_survey/di/interceptor/app_interceptor.dart';
 import 'package:flutter_survey/database/secure_storage.dart';
+import 'package:flutter_survey/usecases/get_auth_token_use_case.dart';
+import 'package:flutter_survey/usecases/refresh_token_use_case.dart';
+import 'package:flutter_survey/usecases/store_auth_token_use_case.dart';
 import 'package:injectable/injectable.dart';
 
 const String headerContentType = 'Content-Type';
@@ -23,6 +26,9 @@ class DioProvider {
       requireAuthentication,
       dio,
       getIt<SecureStorage>(),
+      getIt<RefreshTokenUseCase>(),
+      getIt<StoreAuthTokenUseCase>(),
+      getIt<GetAuthTokenUseCase>(),
     );
     final interceptors = <Interceptor>[];
     interceptors.add(appInterceptor);

--- a/lib/di/provider/dio_provider.dart
+++ b/lib/di/provider/dio_provider.dart
@@ -3,13 +3,12 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_survey/di/di.dart';
 import 'package:flutter_survey/di/interceptor/app_interceptor.dart';
 import 'package:flutter_survey/database/secure_storage.dart';
-import 'package:flutter_survey/usecases/get_auth_token_use_case.dart';
-import 'package:flutter_survey/usecases/refresh_token_use_case.dart';
-import 'package:flutter_survey/usecases/store_auth_token_use_case.dart';
 import 'package:injectable/injectable.dart';
 
 const String headerContentType = 'Content-Type';
 const String defaultContentType = 'application/json; charset=utf-8';
+const Duration _connectTimeoutDuration = Duration(seconds: 3000);
+const Duration _receiveTimeoutDuration = Duration(seconds: 5000);
 
 @Singleton()
 class DioProvider {
@@ -26,9 +25,6 @@ class DioProvider {
       requireAuthentication,
       dio,
       getIt<SecureStorage>(),
-      getIt<RefreshTokenUseCase>(),
-      getIt<StoreAuthTokenUseCase>(),
-      getIt<GetAuthTokenUseCase>(),
     );
     final interceptors = <Interceptor>[];
     interceptors.add(appInterceptor);
@@ -42,8 +38,8 @@ class DioProvider {
     }
 
     return dio
-      ..options.connectTimeout = const Duration(seconds: 3000)
-      ..options.receiveTimeout = const Duration(seconds: 5000)
+      ..options.connectTimeout = _connectTimeoutDuration
+      ..options.receiveTimeout = _receiveTimeoutDuration
       ..options.headers = {headerContentType: defaultContentType}
       ..interceptors.addAll(interceptors);
   }

--- a/lib/di/provider/dio_provider.dart
+++ b/lib/di/provider/dio_provider.dart
@@ -36,8 +36,8 @@ class DioProvider {
     }
 
     return dio
-      ..options.connectTimeout = 3000
-      ..options.receiveTimeout = 5000
+      ..options.connectTimeout = const Duration(seconds: 3000)
+      ..options.receiveTimeout = const Duration(seconds: 5000)
       ..options.headers = {headerContentType: defaultContentType}
       ..interceptors.addAll(interceptors);
   }

--- a/lib/model/auth_token_model.dart
+++ b/lib/model/auth_token_model.dart
@@ -1,14 +1,14 @@
 import 'package:equatable/equatable.dart';
 import 'package:flutter_survey/api/response/login_response.dart';
 
-class LoginModel extends Equatable {
+class AuthTokenModel extends Equatable {
   final String accessToken;
   final String tokenType;
   final int expiresIn;
   final String refreshToken;
   final int createdAt;
 
-  const LoginModel({
+  const AuthTokenModel({
     required this.accessToken,
     required this.tokenType,
     required this.expiresIn,
@@ -20,8 +20,8 @@ class LoginModel extends Equatable {
   List<Object?> get props =>
       [accessToken, tokenType, expiresIn, refreshToken, createdAt];
 
-  factory LoginModel.fromResponse(LoginResponse response) {
-    return LoginModel(
+  factory AuthTokenModel.fromResponse(LoginResponse response) {
+    return AuthTokenModel(
       accessToken: response.accessToken ?? "",
       tokenType: response.tokenType ?? "",
       expiresIn: response.expiresIn ?? 0,

--- a/lib/model/auth_token_model.dart
+++ b/lib/model/auth_token_model.dart
@@ -1,5 +1,5 @@
 import 'package:equatable/equatable.dart';
-import 'package:flutter_survey/api/response/login_response.dart';
+import 'package:flutter_survey/api/response/auth_response.dart';
 
 class AuthTokenModel extends Equatable {
   final String accessToken;
@@ -20,7 +20,7 @@ class AuthTokenModel extends Equatable {
   List<Object?> get props =>
       [accessToken, tokenType, expiresIn, refreshToken, createdAt];
 
-  factory AuthTokenModel.fromResponse(LoginResponse response) {
+  factory AuthTokenModel.fromResponse(AuthResponse response) {
     return AuthTokenModel(
       accessToken: response.accessToken ?? "",
       tokenType: response.tokenType ?? "",

--- a/lib/ui/login/login_view_model.dart
+++ b/lib/ui/login/login_view_model.dart
@@ -1,4 +1,4 @@
-import 'package:flutter_survey/model/login_model.dart';
+import 'package:flutter_survey/model/auth_token_model.dart';
 import 'package:flutter_survey/usecases/base/base_use_case.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_survey/ui/login/login_state.dart';
@@ -21,9 +21,10 @@ class LoginViewModel extends StateNotifier<LoginState> {
       password: password,
     );
     final loginResult = await _logInUseCase.call(input);
-    if (loginResult is Success<LoginModel>) {
-      final LoginModel loginModel = loginResult.value;
-      final storeTokenResult = await _storeAuthTokenUseCase.call(loginModel);
+    if (loginResult is Success<AuthTokenModel>) {
+      final AuthTokenModel authTokenModel = loginResult.value;
+      final storeTokenResult =
+          await _storeAuthTokenUseCase.call(authTokenModel);
       if (storeTokenResult is Success) {
         state = const LoginState.loginSuccess();
       } else {

--- a/lib/usecases/get_auth_token_use_case.dart
+++ b/lib/usecases/get_auth_token_use_case.dart
@@ -3,7 +3,7 @@ import 'package:flutter_survey/model/auth_token_model.dart';
 import 'package:flutter_survey/usecases/base/base_use_case.dart';
 import 'package:injectable/injectable.dart';
 
-@Injectable()
+@Singleton()
 class GetAuthTokenUseCase extends SimpleUseCase<Future<AuthTokenModel>> {
   final SecureStorage _secureStorage;
 

--- a/lib/usecases/get_auth_token_use_case.dart
+++ b/lib/usecases/get_auth_token_use_case.dart
@@ -1,0 +1,29 @@
+import 'package:flutter_survey/database/secure_storage.dart';
+import 'package:flutter_survey/model/auth_token_model.dart';
+import 'package:flutter_survey/usecases/base/base_use_case.dart';
+import 'package:injectable/injectable.dart';
+
+@Injectable()
+class GetAuthTokenUseCase extends SimpleUseCase<Future<AuthTokenModel>> {
+  final SecureStorage _secureStorage;
+
+  GetAuthTokenUseCase(this._secureStorage);
+
+  @override
+  Future<AuthTokenModel> call() async {
+    final String accesstoken =
+        await _secureStorage.readSecureData(accessTokenKey) ?? '';
+    final String refreshToken =
+        await _secureStorage.readSecureData(refreshTokenKey) ?? '';
+    final String tokenType =
+        await _secureStorage.readSecureData(tokenTypeKey) ?? '';
+    final AuthTokenModel authTokenModel = AuthTokenModel(
+      accessToken: accesstoken,
+      tokenType: tokenType,
+      expiresIn: 0,
+      refreshToken: refreshToken,
+      createdAt: 0,
+    );
+    return authTokenModel;
+  }
+}

--- a/lib/usecases/log_in_use_case.dart
+++ b/lib/usecases/log_in_use_case.dart
@@ -2,7 +2,7 @@ import 'package:flutter_survey/api/exception/network_exceptions.dart';
 import 'package:flutter_survey/api/repository/authentication_repository.dart';
 import 'package:flutter_survey/usecases/base/base_use_case.dart';
 import 'package:injectable/injectable.dart';
-import 'package:flutter_survey/model/login_model.dart';
+import 'package:flutter_survey/model/auth_token_model.dart';
 
 class LoginInput {
   final String email;
@@ -15,7 +15,7 @@ class LoginInput {
 }
 
 @Injectable()
-class LogInUseCase extends UseCase<LoginModel, LoginInput> {
+class LogInUseCase extends UseCase<AuthTokenModel, LoginInput> {
   final AuthenticationRepository _authenticationRepository;
 
   const LogInUseCase(
@@ -23,14 +23,14 @@ class LogInUseCase extends UseCase<LoginModel, LoginInput> {
   );
 
   @override
-  Future<Result<LoginModel>> call(LoginInput input) {
+  Future<Result<AuthTokenModel>> call(LoginInput input) {
     return _authenticationRepository
         .logIn(
           email: input.email,
           password: input.password,
         )
         // ignore: unnecessary_cast
-        .then((value) => Success(value) as Result<LoginModel>)
+        .then((value) => Success(value) as Result<AuthTokenModel>)
         .onError<NetworkExceptions>((ex, _) => Failed(UseCaseException(ex)));
   }
 }

--- a/lib/usecases/refresh_token_use_case.dart
+++ b/lib/usecases/refresh_token_use_case.dart
@@ -4,7 +4,7 @@ import 'package:injectable/injectable.dart';
 import 'package:flutter_survey/usecases/base/base_use_case.dart';
 import 'package:flutter_survey/api/exception/network_exceptions.dart';
 
-@Injectable()
+@Singleton()
 class RefreshTokenUseCase extends UseCase<AuthTokenModel, String> {
   final AuthenticationRepository _authenticationRepository;
 

--- a/lib/usecases/refresh_token_use_case.dart
+++ b/lib/usecases/refresh_token_use_case.dart
@@ -1,11 +1,11 @@
 import 'package:flutter_survey/api/repository/authentication_repository.dart';
-import 'package:flutter_survey/model/login_model.dart';
+import 'package:flutter_survey/model/auth_token_model.dart';
 import 'package:injectable/injectable.dart';
 import 'package:flutter_survey/usecases/base/base_use_case.dart';
 import 'package:flutter_survey/api/exception/network_exceptions.dart';
 
 @Injectable()
-class RefreshTokenUseCase extends UseCase<LoginModel, String> {
+class RefreshTokenUseCase extends UseCase<AuthTokenModel, String> {
   final AuthenticationRepository _authenticationRepository;
 
   const RefreshTokenUseCase(
@@ -13,11 +13,11 @@ class RefreshTokenUseCase extends UseCase<LoginModel, String> {
   );
 
   @override
-  Future<Result<LoginModel>> call(String input) {
+  Future<Result<AuthTokenModel>> call(String input) {
     return _authenticationRepository
         .getAuthToken(refreshToken: input)
         // ignore: unnecessary_cast
-        .then((value) => Success(value) as Result<LoginModel>)
+        .then((value) => Success(value) as Result<AuthTokenModel>)
         .onError<NetworkExceptions>((ex, _) => Failed(UseCaseException(ex)));
   }
 }

--- a/lib/usecases/refresh_token_use_case.dart
+++ b/lib/usecases/refresh_token_use_case.dart
@@ -1,0 +1,23 @@
+import 'package:flutter_survey/api/repository/authentication_repository.dart';
+import 'package:flutter_survey/model/login_model.dart';
+import 'package:injectable/injectable.dart';
+import 'package:flutter_survey/usecases/base/base_use_case.dart';
+import 'package:flutter_survey/api/exception/network_exceptions.dart';
+
+@Injectable()
+class RefreshTokenUseCase extends UseCase<LoginModel, String> {
+  final AuthenticationRepository _authenticationRepository;
+
+  const RefreshTokenUseCase(
+    this._authenticationRepository,
+  );
+
+  @override
+  Future<Result<LoginModel>> call(String input) {
+    return _authenticationRepository
+        .getAuthToken(refreshToken: input)
+        // ignore: unnecessary_cast
+        .then((value) => Success(value) as Result<LoginModel>)
+        .onError<NetworkExceptions>((ex, _) => Failed(UseCaseException(ex)));
+  }
+}

--- a/lib/usecases/refresh_token_use_case.dart
+++ b/lib/usecases/refresh_token_use_case.dart
@@ -15,7 +15,7 @@ class RefreshTokenUseCase extends UseCase<AuthTokenModel, String> {
   @override
   Future<Result<AuthTokenModel>> call(String input) {
     return _authenticationRepository
-        .getAuthToken(refreshToken: input)
+        .refreshToken(refreshToken: input)
         // ignore: unnecessary_cast
         .then((value) => Success(value) as Result<AuthTokenModel>)
         .onError<NetworkExceptions>((ex, _) => Failed(UseCaseException(ex)));

--- a/lib/usecases/store_auth_token_use_case.dart
+++ b/lib/usecases/store_auth_token_use_case.dart
@@ -1,3 +1,4 @@
+import 'package:flutter_survey/model/auth_token_model.dart';
 import 'package:flutter_survey/usecases/base/base_use_case.dart';
 import 'package:flutter_survey/database/secure_storage.dart';
 import 'package:injectable/injectable.dart';

--- a/lib/usecases/store_auth_token_use_case.dart
+++ b/lib/usecases/store_auth_token_use_case.dart
@@ -3,7 +3,7 @@ import 'package:flutter_survey/usecases/base/base_use_case.dart';
 import 'package:flutter_survey/database/secure_storage.dart';
 import 'package:injectable/injectable.dart';
 
-@Injectable()
+@Singleton()
 class StoreAuthTokenUseCase extends UseCase<void, AuthTokenModel> {
   final SecureStorage _secureStorage;
 

--- a/lib/usecases/store_auth_token_use_case.dart
+++ b/lib/usecases/store_auth_token_use_case.dart
@@ -1,16 +1,15 @@
-import 'package:flutter_survey/model/login_model.dart';
 import 'package:flutter_survey/usecases/base/base_use_case.dart';
 import 'package:flutter_survey/database/secure_storage.dart';
 import 'package:injectable/injectable.dart';
 
 @Injectable()
-class StoreAuthTokenUseCase extends UseCase<void, LoginModel> {
+class StoreAuthTokenUseCase extends UseCase<void, AuthTokenModel> {
   final SecureStorage _secureStorage;
 
   const StoreAuthTokenUseCase(this._secureStorage);
 
   @override
-  Future<Result<void>> call(LoginModel input) async {
+  Future<Result<void>> call(AuthTokenModel input) async {
     try {
       await _secureStorage.writeSecureData(accessTokenKey, input.accessToken);
       await _secureStorage.writeSecureData(refreshTokenKey, input.refreshToken);

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -205,10 +205,10 @@ packages:
     dependency: "direct main"
     description:
       name: dio
-      sha256: "7d328c4d898a61efc3cd93655a0955858e29a0aa647f0f9e02d59b3bb275e2e8"
+      sha256: "0894a098594263fe1caaba3520e3016d8a855caeb010a882273189cca10f11e9"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.6"
+    version: "5.1.1"
   email_validator:
     dependency: "direct main"
     description:
@@ -832,18 +832,18 @@ packages:
     dependency: "direct main"
     description:
       name: retrofit
-      sha256: "9254ec985d5e26a839a9070ae25b98f0781c9c420e4241c5fb8b8965aa1fc7f2"
+      sha256: "5eedbd8f73697f190dabc88520e0bcf2d3b2d9b9ad5c837f1dbb3ee6172d7709"
       url: "https://pub.dev"
     source: hosted
-    version: "3.3.1"
+    version: "4.0.1"
   retrofit_generator:
     dependency: "direct dev"
     description:
       name: retrofit_generator
-      sha256: f5107e842e77ce71c63b995331b43d4597f71df9031389dd93a1197a00118d83
+      sha256: "5289b5cfc73ba123e238b9d3348a143fcb7f9d93c821525868f8dc3bb497c499"
       url: "https://pub.dev"
     source: hosted
-    version: "4.2.0"
+    version: "5.0.0+1"
   riverpod:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,7 +22,7 @@ environment:
 
 dependencies:
   cupertino_icons: ^1.0.5
-  dio: ^4.0.6
+  dio: ^5.0.0
   equatable: ^2.0.5
   hive: ^2.2.3
   hive_flutter: ^1.1.0
@@ -42,7 +42,7 @@ dependencies:
   package_info_plus: ^1.4.2
   page_view_dot_indicator: ^2.0.1
   permission_handler: ^10.2.0
-  retrofit: ^3.0.1+1
+  retrofit: '>=4.0.0 <5.0.0'
   rxdart: ^0.27.7
   shimmer: ^2.0.0
   email_validator: '^2.1.16'
@@ -61,7 +61,7 @@ dev_dependencies:
     sdk: flutter
   json_serializable: ^6.3.1
   mockito: ^5.2.0
-  retrofit_generator: ^4.0.1
+  retrofit_generator: '>=5.0.0 <6.0.0'
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/test/api/repository/authentication_repository_test.dart
+++ b/test/api/repository/authentication_repository_test.dart
@@ -66,10 +66,10 @@ void main() {
             await FileUtils.loadFile('test/mock_responses/login_data.json');
         final authResponse = AuthResponse.fromJson(json);
 
-        when(mockAuthenticationService.getAuthToken(any))
+        when(mockAuthenticationService.refreshToken(any))
             .thenAnswer((_) async => authResponse);
 
-        final loginModel = await authenticationRepository.getAuthToken(
+        final loginModel = await authenticationRepository.refreshToken(
             refreshToken: 'refreshToken');
 
         expect(loginModel.accessToken,
@@ -83,10 +83,10 @@ void main() {
     test(
       "When refresh token failed, it emits network exception",
       () async {
-        when(mockAuthenticationService.getAuthToken(any))
+        when(mockAuthenticationService.refreshToken(any))
             .thenThrow(MockDioError());
         result() =>
-            authenticationRepository.getAuthToken(refreshToken: 'refreshToken');
+            authenticationRepository.refreshToken(refreshToken: 'refreshToken');
         expect(result, throwsA(isA<NetworkExceptions>()));
       },
     );

--- a/test/api/repository/authentication_repository_test.dart
+++ b/test/api/repository/authentication_repository_test.dart
@@ -1,6 +1,6 @@
 import 'package:flutter_config/flutter_config.dart';
 import 'package:flutter_survey/api/repository/authentication_repository.dart';
-import 'package:flutter_survey/api/response/login_response.dart';
+import 'package:flutter_survey/api/response/auth_response.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_survey/api/exception/network_exceptions.dart';
 import 'package:mockito/mockito.dart';
@@ -30,10 +30,10 @@ void main() {
       () async {
         final json =
             await FileUtils.loadFile('test/mock_responses/login_data.json');
-        final loginResponse = LoginResponse.fromJson(json);
+        final authResponse = AuthResponse.fromJson(json);
 
         when(mockAuthenticationService.logIn(any))
-            .thenAnswer((_) async => loginResponse);
+            .thenAnswer((_) async => authResponse);
 
         final loginModel = await authenticationRepository.logIn(
           email: "email",
@@ -64,10 +64,10 @@ void main() {
       () async {
         final json =
             await FileUtils.loadFile('test/mock_responses/login_data.json');
-        final loginResponse = LoginResponse.fromJson(json);
+        final authResponse = AuthResponse.fromJson(json);
 
         when(mockAuthenticationService.getAuthToken(any))
-            .thenAnswer((_) async => loginResponse);
+            .thenAnswer((_) async => authResponse);
 
         final loginModel = await authenticationRepository.getAuthToken(
             refreshToken: 'refreshToken');
@@ -83,9 +83,6 @@ void main() {
     test(
       "When refresh token failed, it emits network exception",
       () async {
-        final json =
-            await FileUtils.loadFile('test/mock_responses/login_data.json');
-
         when(mockAuthenticationService.getAuthToken(any))
             .thenThrow(MockDioError());
         result() =>

--- a/test/api/repository/authentication_repository_test.dart
+++ b/test/api/repository/authentication_repository_test.dart
@@ -58,5 +58,40 @@ void main() {
         expect(result, throwsA(isA<NetworkExceptions>()));
       },
     );
+
+    test(
+      "When refresh token success, it returns new token data",
+      () async {
+        final json =
+            await FileUtils.loadFile('test/mock_responses/login_data.json');
+        final loginResponse = LoginResponse.fromJson(json);
+
+        when(mockAuthenticationService.getAuthToken(any))
+            .thenAnswer((_) async => loginResponse);
+
+        final loginModel = await authenticationRepository.getAuthToken(
+            refreshToken: 'refreshToken');
+
+        expect(loginModel.accessToken,
+            "lbxD2K2BjbYtNzz8xjvh2FvSKx838KBCf79q773kq2c");
+        expect(loginModel.tokenType, 'Bearer');
+        expect(loginModel.refreshToken,
+            '3zJz2oW0njxlj_I3ghyUBF7ZfdQKYXd2n0ODlMkAjHc');
+      },
+    );
+
+    test(
+      "When refresh token failed, it emits network exception",
+      () async {
+        final json =
+            await FileUtils.loadFile('test/mock_responses/login_data.json');
+
+        when(mockAuthenticationService.getAuthToken(any))
+            .thenThrow(MockDioError());
+        result() =>
+            authenticationRepository.getAuthToken(refreshToken: 'refreshToken');
+        expect(result, throwsA(isA<NetworkExceptions>()));
+      },
+    );
   });
 }

--- a/test/ui/login/login_view_model_test.dart
+++ b/test/ui/login/login_view_model_test.dart
@@ -6,7 +6,7 @@ import 'package:mockito/mockito.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_survey/api/exception/network_exceptions.dart';
 import 'package:flutter_survey/usecases/base/base_use_case.dart';
-import 'package:flutter_survey/model/login_model.dart';
+import 'package:flutter_survey/model/auth_token_model.dart';
 
 import '../../mocks/generate_mocks.mocks.dart';
 
@@ -18,7 +18,7 @@ void main() {
       late MockLogInUseCase mockLogInUseCase;
       late MockStoreAuthTokenUseCase mockStoreAuthTokenUseCase;
       late ProviderContainer providerContainer;
-      const loginModel = LoginModel(
+      const authTokenModel = AuthTokenModel(
         accessToken: "accessToken",
         tokenType: "tokenType",
         expiresIn: 10,
@@ -55,7 +55,7 @@ void main() {
         'When logging in & storing the token successfully, it emits loginSuccess state to navigate to the Home screen',
         () async {
           when(mockLogInUseCase.call(any)).thenAnswer(
-            (_) async => Success(loginModel),
+            (_) async => Success(authTokenModel),
           );
           when(mockStoreAuthTokenUseCase.call(any)).thenAnswer(
             (_) async => Success(null),
@@ -80,7 +80,7 @@ void main() {
           final mockException = MockUseCaseException();
           when(mockException.actualException).thenReturn(Exception());
           when(mockLogInUseCase.call(any)).thenAnswer(
-            (_) async => Success(loginModel),
+            (_) async => Success(authTokenModel),
           );
           when(mockStoreAuthTokenUseCase.call(any)).thenAnswer(
             (_) async => Failed(mockException),

--- a/test/usecases/get_auth_token_use_case_test.dart
+++ b/test/usecases/get_auth_token_use_case_test.dart
@@ -5,7 +5,7 @@ import 'package:mockito/mockito.dart';
 import '../mocks/generate_mocks.mocks.dart';
 
 void main() {
-  group('GetLogInStatusUseCaseTest', () {
+  group('GetAuthTokenUseCaseTest', () {
     late MockSecureStorage mockSecureStorage;
     late GetAuthTokenUseCase getAuthTokenUseCase;
 
@@ -14,7 +14,7 @@ void main() {
       getAuthTokenUseCase = GetAuthTokenUseCase(mockSecureStorage);
     });
 
-    test('When fetching auth token data it returns accordingly', () async {
+    test('When fetch auth token data it returns accordingly', () async {
       when(mockSecureStorage.readSecureData(accessTokenKey))
           .thenAnswer((_) async => 'accessToken');
       when(mockSecureStorage.readSecureData(tokenTypeKey))

--- a/test/usecases/get_auth_token_use_case_test.dart
+++ b/test/usecases/get_auth_token_use_case_test.dart
@@ -1,0 +1,31 @@
+import 'package:flutter_survey/database/secure_storage.dart';
+import 'package:flutter_survey/usecases/get_auth_token_use_case.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import '../mocks/generate_mocks.mocks.dart';
+
+void main() {
+  group('GetLogInStatusUseCaseTest', () {
+    late MockSecureStorage mockSecureStorage;
+    late GetAuthTokenUseCase getAuthTokenUseCase;
+
+    setUp(() async {
+      mockSecureStorage = MockSecureStorage();
+      getAuthTokenUseCase = GetAuthTokenUseCase(mockSecureStorage);
+    });
+
+    test('When fetching auth token data it returns accordingly', () async {
+      when(mockSecureStorage.readSecureData(accessTokenKey))
+          .thenAnswer((_) async => 'accessToken');
+      when(mockSecureStorage.readSecureData(tokenTypeKey))
+          .thenAnswer((_) async => 'tokenType');
+      when(mockSecureStorage.readSecureData(refreshTokenKey))
+          .thenAnswer((_) async => 'refreshToken');
+      final result = await getAuthTokenUseCase.call();
+
+      expect(result.accessToken, 'accessToken');
+      expect(result.tokenType, 'tokenType');
+      expect(result.refreshToken, 'refreshToken');
+    });
+  });
+}

--- a/test/usecases/get_auth_token_use_case_test.dart
+++ b/test/usecases/get_auth_token_use_case_test.dart
@@ -14,7 +14,7 @@ void main() {
       getAuthTokenUseCase = GetAuthTokenUseCase(mockSecureStorage);
     });
 
-    test('When fetch auth token data it returns accordingly', () async {
+    test('When fetch auth token data it, returns accordingly', () async {
       when(mockSecureStorage.readSecureData(accessTokenKey))
           .thenAnswer((_) async => 'accessToken');
       when(mockSecureStorage.readSecureData(tokenTypeKey))

--- a/test/usecases/log_in_use_case_test.dart
+++ b/test/usecases/log_in_use_case_test.dart
@@ -1,5 +1,5 @@
 import 'package:flutter_survey/api/exception/network_exceptions.dart';
-import 'package:flutter_survey/model/login_model.dart';
+import 'package:flutter_survey/model/auth_token_model.dart';
 import 'package:flutter_survey/usecases/base/base_use_case.dart';
 import 'package:flutter_survey/usecases/log_in_use_case.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -22,7 +22,7 @@ void main() {
 
     test('When call execution has succeeded, it returns a Success result',
         () async {
-      const loginModel = LoginModel(
+      const authTokenModel = AuthTokenModel(
         accessToken: "accessToken",
         tokenType: "tokenType",
         expiresIn: 10,
@@ -35,12 +35,12 @@ void main() {
           email: "email",
           password: "password",
         ),
-      ).thenAnswer((_) async => loginModel);
+      ).thenAnswer((_) async => authTokenModel);
 
       final result = await loginUseCase.call(loginInput);
 
       expect(result, isA<Success>());
-      expect((result as Success).value, loginModel);
+      expect((result as Success).value, authTokenModel);
     });
 
     test('When call execution has failed, it returns a Failed result',

--- a/test/usecases/refresh_token_use_case_test.dart
+++ b/test/usecases/refresh_token_use_case_test.dart
@@ -26,7 +26,7 @@ void main() {
         createdAt: 1,
       );
       when(
-        mockAuthenticationRepository.getAuthToken(refreshToken: 'refreshToken'),
+        mockAuthenticationRepository.refreshToken(refreshToken: 'refreshToken'),
       ).thenAnswer((_) async => authTokenModel);
 
       final result = await refreshTokenUseCase.call('refreshToken');
@@ -38,7 +38,7 @@ void main() {
     test('When call execution has failed, it returns a Failed result',
         () async {
       const exception = NetworkExceptions.badRequest();
-      when(mockAuthenticationRepository.getAuthToken(
+      when(mockAuthenticationRepository.refreshToken(
               refreshToken: 'refreshToken'))
           .thenAnswer((_) => Future.error(exception));
 

--- a/test/usecases/refresh_token_use_case_test.dart
+++ b/test/usecases/refresh_token_use_case_test.dart
@@ -1,5 +1,5 @@
 import 'package:flutter_survey/api/exception/network_exceptions.dart';
-import 'package:flutter_survey/model/login_model.dart';
+import 'package:flutter_survey/model/auth_token_model.dart';
 import 'package:flutter_survey/usecases/base/base_use_case.dart';
 import 'package:flutter_survey/usecases/refresh_token_use_case.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -18,7 +18,7 @@ void main() {
 
     test('When call execution has succeeded, it returns a Success result',
         () async {
-      const loginModel = LoginModel(
+      const authTokenModel = AuthTokenModel(
         accessToken: "accessToken",
         tokenType: "tokenType",
         expiresIn: 10,
@@ -27,20 +27,20 @@ void main() {
       );
       when(
         mockAuthenticationRepository.getAuthToken(refreshToken: 'refreshToken'),
-      ).thenAnswer((_) async => loginModel);
+      ).thenAnswer((_) async => authTokenModel);
 
       final result = await refreshTokenUseCase.call('refreshToken');
 
       expect(result, isA<Success>());
-      expect((result as Success).value, loginModel);
+      expect((result as Success).value, authTokenModel);
     });
 
     test('When call execution has failed, it returns a Failed result',
         () async {
       const exception = NetworkExceptions.badRequest();
-      when(
-        mockAuthenticationRepository.getAuthToken(refreshToken: 'refreshToken')
-      ).thenAnswer((_) => Future.error(exception));
+      when(mockAuthenticationRepository.getAuthToken(
+              refreshToken: 'refreshToken'))
+          .thenAnswer((_) => Future.error(exception));
 
       final result = await refreshTokenUseCase.call('refreshToken');
 

--- a/test/usecases/refresh_token_use_case_test.dart
+++ b/test/usecases/refresh_token_use_case_test.dart
@@ -1,0 +1,51 @@
+import 'package:flutter_survey/api/exception/network_exceptions.dart';
+import 'package:flutter_survey/model/login_model.dart';
+import 'package:flutter_survey/usecases/base/base_use_case.dart';
+import 'package:flutter_survey/usecases/refresh_token_use_case.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import '../mocks/generate_mocks.mocks.dart';
+
+void main() {
+  group('RefreshTokenUseCaseTest', () {
+    late MockAuthenticationRepository mockAuthenticationRepository;
+    late RefreshTokenUseCase refreshTokenUseCase;
+
+    setUp(() async {
+      mockAuthenticationRepository = MockAuthenticationRepository();
+      refreshTokenUseCase = RefreshTokenUseCase(mockAuthenticationRepository);
+    });
+
+    test('When call execution has succeeded, it returns a Success result',
+        () async {
+      const loginModel = LoginModel(
+        accessToken: "accessToken",
+        tokenType: "tokenType",
+        expiresIn: 10,
+        refreshToken: "refreshToken",
+        createdAt: 1,
+      );
+      when(
+        mockAuthenticationRepository.getAuthToken(refreshToken: 'refreshToken'),
+      ).thenAnswer((_) async => loginModel);
+
+      final result = await refreshTokenUseCase.call('refreshToken');
+
+      expect(result, isA<Success>());
+      expect((result as Success).value, loginModel);
+    });
+
+    test('When call execution has failed, it returns a Failed result',
+        () async {
+      const exception = NetworkExceptions.badRequest();
+      when(
+        mockAuthenticationRepository.getAuthToken(refreshToken: 'refreshToken')
+      ).thenAnswer((_) => Future.error(exception));
+
+      final result = await refreshTokenUseCase.call('refreshToken');
+
+      expect(result, isA<Failed>());
+      expect((result as Failed).exception.actualException, exception);
+    });
+  });
+}

--- a/test/usecases/store_auth_token_use_case_test.dart
+++ b/test/usecases/store_auth_token_use_case_test.dart
@@ -1,4 +1,4 @@
-import 'package:flutter_survey/model/login_model.dart';
+import 'package:flutter_survey/model/auth_token_model.dart';
 import 'package:flutter_survey/usecases/base/base_use_case.dart';
 import 'package:flutter_survey/usecases/store_auth_token_use_case.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -18,14 +18,14 @@ void main() {
     test(
         'When save execution has succeeded, data saved in secure storage successfully',
         () async {
-      const loginModel = LoginModel(
+      const authTokenModel = AuthTokenModel(
         accessToken: "accessToken",
         tokenType: "tokenType",
         expiresIn: 10,
         refreshToken: "refreshToken",
         createdAt: 1,
       );
-      final result = await storeAuthTokenUseCase.call(loginModel);
+      final result = await storeAuthTokenUseCase.call(authTokenModel);
       expect(result, isA<Success>());
       expect((result as Success).value, null);
     });
@@ -35,14 +35,14 @@ void main() {
       final exception = Exception("storage exception");
       when(mockSecureStorage.writeSecureData(any, any))
           .thenAnswer((_) => Future.error(exception));
-      const loginModel = LoginModel(
+      const authTokenModel = AuthTokenModel(
         accessToken: "accessToken",
         tokenType: "tokenType",
         expiresIn: 10,
         refreshToken: "refreshToken",
         createdAt: 1,
       );
-      final result = await storeAuthTokenUseCase.call(loginModel);
+      final result = await storeAuthTokenUseCase.call(authTokenModel);
       expect(result, isA<Failed>());
       expect((result as Failed).exception.actualException, exception);
     });


### PR DESCRIPTION
#19 
#20 
## What happened 👀
- Update `Dio` and `Retrofit`
- Change class name `LoginModel` to `AuthTokenModel`
- Change class name `LoginResponse` to `AuthResponse`
- Update `NetworkExceptions` and `DioProvider` to adapt the new `Dio` and `Retrofit` version
- Add new method `getAuthToken` in `AuthenticationRepository` to make refresh token request
- Add new class `RefreshTokenRequest` to generate refresh token request body
- Handle refresh token request-response in `AppInterceptor`
- Write unit test for repository and usecase

## Insight 📝

- Faced [bad state error](https://stackoverflow.com/questions/73106834/flutter-dio-interceptor-error-bad-state-future-already-completed), so upgrade the `Dio` and `Retrofit` 
- Follow flutter's template code to refresh token and re-send survey request
- Rename classes `LoginModel` to `AuthTokenModel` and `LoginResponse` to `AuthResponse` so as they are using both for login and refresh token.

## Proof Of Work 📹

- First request of Survey list:
![Screenshot 2023-04-21 at 5 48 59 PM](https://user-images.githubusercontent.com/13636465/233617869-f4a03fa9-2de9-4c07-b2ed-7915fbc18e7e.png)

- Then request for access token using refresh_token

![Screenshot 2023-04-21 at 5 50 13 PM](https://user-images.githubusercontent.com/13636465/233618266-347c8352-378e-44b0-8bbb-c0bc546c9638.png)

- Receive new token as response
![Screenshot 2023-04-21 at 5 53 37 PM](https://user-images.githubusercontent.com/13636465/233618966-cc29d011-1021-4c93-9569-8da3a6122668.png)

- Sent survey request again and receive response data
![Screenshot 2023-04-21 at 5 55 25 PM](https://user-images.githubusercontent.com/13636465/233619188-01e21606-4b23-4ff4-8b51-3fdc3b51668c.png)


