### PR TITLE
[Bug] Fix back button navigates to white screen

### DIFF
--- a/lib/app_navigator.dart
+++ b/lib/app_navigator.dart
@@ -63,12 +63,12 @@ class AppNavigatorImpl extends AppNavigator {
 
   @override
   void navigateToHomeScreen({required BuildContext context}) {
-    context.replace('$_routePathRootScreen$_routePathHomeScreen');
+    context.replace('/$_routePathHomeScreen');
   }
 
   @override
   void navigateToLoginScreen({required BuildContext context}) {
-    context.replace('$_routePathRootScreen$_routePathLoginScreen');
+    context.replace('/$_routePathLoginScreen');
   }
 
   @override
@@ -76,6 +76,6 @@ class AppNavigatorImpl extends AppNavigator {
     required BuildContext context,
     required String surveyId,
   }) {
-    context.go('/$_routePathFormScreen/$surveyId');
+    context.push('/$_routePathFormScreen/$surveyId');
   }
 }


### PR DESCRIPTION
## What happened 👀

When pressing the back button or close button from the form screen, it showed a white screen

https://user-images.githubusercontent.com/18277915/234168680-65051878-d28e-41f0-a315-ca43e8c25d65.mov

## Insight 📝

Use `push` instead of `go`:

**Chat GPT** 🤖

> The push method is used to navigate to a new screen and add it to the navigation stack. This means that the previous screen is still accessible and can be returned to by pressing the back button on the app bar or the device. On the other hand, the go method is typically used to replace the current screen with a new one. This means that the previous screen is removed from the navigation stack, and the new screen becomes the active one.

## Proof Of Work 📹

https://user-images.githubusercontent.com/18277915/234168997-3c137756-8bd6-46df-8ee3-125b1ddac583.mov
